### PR TITLE
Fix server start script for production

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -13,9 +13,14 @@ In the project directory, you can run:
 This will install all of the dependencies you need.
 
 ### `yarn start`
+Runs the app compiled using `yarn compile` for production mode.
+To run the most updated version of your code, make sure to run `yarn compile`
+before running `yarn start`.
+
+### `yarn start:dev`
 
 Runs the app in the development mode.<br />
-Receives REST API requests at [http://localhost:5000](http://localhost:5000).
+Receives REST API requests at [http://localhost:8080](http://localhost:8080).
 You can use [Postman](https://www.postman.com/downloads/) to send REST requests
 and view the responses.<br />
 

--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ before running `yarn start`.
 ### `yarn start:dev`
 
 Runs the app in the development mode.<br />
-Receives REST API requests at [http://localhost:8080](http://localhost:8080).
+Receives REST API requests at [http://localhost:5000](http://localhost:5000).
 You can use [Postman](https://www.postman.com/downloads/) to send REST requests
 and view the responses.<br />
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,12 +1,12 @@
 {
   "name": "gpay-group-buy-server",
   "version": "1.0.0",
-  "main": "src/index.ts",
   "repository": "git@github.com:googleinterns/gpay-group-buy.git",
   "author": "Karen Frilya Celine",
   "license": "Apache-2.0",
   "scripts": {
-    "start": "nodemon",
+    "start": "node build/src/index.js",
+    "start:dev": "nodemon -r tsconfig-paths/register src/index.ts",
     "lint": "gts check",
     "fix": "gts fix",
     "clean": "gts clean",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,6 @@ router.use('/merchants', merchantsRouter);
 
 app.use('/', router);
 
-const port = process.env.port || 5000;
+const port = process.env.PORT || 8080;
 app.listen(port);
 console.log(`Listening on port ${port}`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,6 @@ router.use('/merchants', merchantsRouter);
 
 app.use('/', router);
 
-const port = process.env.PORT || 8080;
+const port = process.env.PORT || 5000;
 app.listen(port);
 console.log(`Listening on port ${port}`);


### PR DESCRIPTION
Changes made:
- Changed `yarn start` command to run compiled code for production
- Added `yarn start:dev` command to run current code for development

Previously `yarn start` command ran code in development mode which caused error when deployed to the server. This PR fixes that problem.