### PR TITLE
Add Card components

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -38,7 +38,9 @@
           "caseInsensitive": true
         }
       }
-    ]
+    ],
+    // TypeScript lints this for us
+    "react/prop-types": "off"
   },
   "settings": {
     "react": {

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -23,12 +23,15 @@ import {Switch, Route} from 'react-router-dom';
 const CustomerExplorePage = lazy(() => import('components/customer/explore'));
 // Merchant Pages
 const MerchantLandingPage = lazy(() => import('components/merchant/landing'));
+// Design samples
+const DesignSamplesPage = lazy(() => import('components/design-samples'));
 
 const Routes: React.FC = () => (
   <Suspense fallback={<Loading />}>
     <Switch>
       <Route exact path="/" component={CustomerExplorePage} />
       <Route exact path="/merchant" component={MerchantLandingPage} />
+      <Route exact path="/design-samples" component={DesignSamplesPage} />
     </Switch>
   </Suspense>
 );

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -20,6 +20,8 @@ import CardImage from 'components/common/CardImage';
 import {Image} from 'interfaces';
 import styled from 'styled-components';
 
+const DEFAULT_IMG_WIDTH = '150px';
+
 interface CardContainerProps {
   imgLeft?: boolean;
 }
@@ -50,6 +52,9 @@ interface CardProps {
   imgLeft?: boolean;
 }
 
+/**
+ * A base Card component that takes in images.
+ */
 const Card: React.FC<CardProps> = ({img, imgLeft, children}) => (
   <CardContainer imgLeft={imgLeft}>
     {img !== undefined && (

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -23,13 +23,13 @@ import styled from 'styled-components';
 const DEFAULT_IMG_WIDTH = '150px';
 
 interface CardContainerProps {
-  imgLeft?: boolean;
+  horizontal?: boolean;
 }
 
 const CardContainer = styled.div`
   display: flex;
-  flex-direction: ${({imgLeft}: CardContainerProps) =>
-    imgLeft ? 'row' : 'column'};
+  flex-direction: ${({horizontal}: CardContainerProps) =>
+    horizontal ? 'row' : 'column'};
 
   background: white;
   margin: 0.6em;
@@ -49,20 +49,20 @@ const CardContent = styled.div`
 
 interface CardProps {
   img?: Image;
-  imgLeft?: boolean;
+  horizontal?: boolean;
 }
 
 /**
  * A base Card component that takes in images.
  */
-const Card: React.FC<CardProps> = ({img, imgLeft, children}) => (
-  <CardContainer imgLeft={imgLeft}>
+const Card: React.FC<CardProps> = ({img, horizontal, children}) => (
+  <CardContainer horizontal={horizontal}>
     {img !== undefined && (
       <ImageContainer>
         <CardImage
           img={img}
-          width={imgLeft ? '150px' : undefined}
-          height={imgLeft ? '100%' : undefined}
+          width={horizontal ? DEFAULT_IMG_WIDTH : undefined}
+          height={horizontal ? '100%' : undefined}
         />
       </ImageContainer>
     )}

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+import CardImage from 'components/common/CardImage';
+import {Image} from 'interfaces';
+
+interface CardContainerProps {
+  imgLeft?: boolean;
+}
+
+const CardContainer = styled.div`
+  display: flex;
+  flex-direction: ${({imgLeft}: CardContainerProps) =>
+    imgLeft ? 'row' : 'column'};
+
+  background: white;
+  margin: 0.6em;
+  overflow: hidden;
+  border-radius: 15px;
+  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.25);
+`;
+
+interface CardProps {
+  img?: Image;
+  imgLeft?: boolean;
+}
+
+const Card: React.FC<CardProps> = ({img, imgLeft, children}) => (
+  <CardContainer imgLeft={imgLeft}>
+    {img !== undefined && (
+      <CardImage img={img} width={imgLeft ? '150px' : undefined} />
+    )}
+    {children}
+  </CardContainer>
+);
+
+export default Card;

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -16,10 +16,9 @@
 
 import React from 'react';
 
-import styled from 'styled-components';
-
 import CardImage from 'components/common/CardImage';
 import {Image} from 'interfaces';
+import styled from 'styled-components';
 
 interface CardContainerProps {
   imgLeft?: boolean;

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -37,6 +37,15 @@ const CardContainer = styled.div`
   box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.25);
 `;
 
+const ImageContainer = styled.div`
+  flex-shrink: 0;
+`;
+
+const CardContent = styled.div`
+  padding: 0.8em;
+  flex-grow: 1;
+`;
+
 interface CardProps {
   img?: Image;
   imgLeft?: boolean;
@@ -45,9 +54,15 @@ interface CardProps {
 const Card: React.FC<CardProps> = ({img, imgLeft, children}) => (
   <CardContainer imgLeft={imgLeft}>
     {img !== undefined && (
-      <CardImage img={img} width={imgLeft ? '150px' : undefined} />
+      <ImageContainer>
+        <CardImage
+          img={img}
+          width={imgLeft ? '150px' : undefined}
+          height={imgLeft ? '100%' : undefined}
+        />
+      </ImageContainer>
     )}
-    {children}
+    <CardContent>{children}</CardContent>
   </CardContainer>
 );
 

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -53,7 +53,7 @@ interface CardProps {
 }
 
 /**
- * A base Card component that takes in images.
+ * A base Card component that can also display images.
  */
 const Card: React.FC<CardProps> = ({img, horizontal, children}) => (
   <CardContainer horizontal={horizontal}>

--- a/web/src/components/common/CardImage.tsx
+++ b/web/src/components/common/CardImage.tsx
@@ -27,11 +27,10 @@ interface CardContainerProps {
   height?: string;
 }
 
-const CardContainer = styled.div`
+const ImageContainer = styled.div`
   width: ${({width}: CardContainerProps) => width || '100%'};
-  min-height: DEFAULT_IMG_HEIGHT;
-  height: ${({height}: CardContainerProps) => height || MIN_IMG_HEIGHT};
-  overflow: hidden;
+  min-height: ${MIN_IMG_HEIGHT};
+  height: ${({ height }: CardContainerProps) => height || MIN_IMG_HEIGHT};
 `;
 
 const StyledCardImage = styled.img`
@@ -48,9 +47,9 @@ interface CardImageProps {
 }
 
 const CardImage: React.FC<CardImageProps> = ({img, width, height}) => (
-  <CardContainer width={width} height={height}>
+  <ImageContainer width={width} height={height}>
     <StyledCardImage src={img.url} alt={img.alt || 'Card Image'} />
-  </CardContainer>
+  </ImageContainer>
 );
 
 export default CardImage;

--- a/web/src/components/common/CardImage.tsx
+++ b/web/src/components/common/CardImage.tsx
@@ -16,9 +16,8 @@
 
 import React from 'react';
 
-import styled from 'styled-components';
-
 import {Image} from 'interfaces';
+import styled from 'styled-components';
 
 const MIN_IMG_HEIGHT = '120px';
 
@@ -30,7 +29,7 @@ interface CardContainerProps {
 const ImageContainer = styled.div`
   width: ${({width}: CardContainerProps) => width || '100%'};
   min-height: ${MIN_IMG_HEIGHT};
-  height: ${({ height }: CardContainerProps) => height || MIN_IMG_HEIGHT};
+  height: ${({height}: CardContainerProps) => height || MIN_IMG_HEIGHT};
 `;
 
 const StyledCardImage = styled.img`

--- a/web/src/components/common/CardImage.tsx
+++ b/web/src/components/common/CardImage.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+import {Image} from 'interfaces';
+
+const MIN_IMG_HEIGHT = '120px';
+
+interface CardContainerProps {
+  width?: string;
+  height?: string;
+}
+
+const CardContainer = styled.div`
+  width: ${({width}: CardContainerProps) => width || '100%'};
+  min-height: DEFAULT_IMG_HEIGHT;
+  height: ${({height}: CardContainerProps) => height || MIN_IMG_HEIGHT};
+  overflow: hidden;
+`;
+
+const StyledCardImage = styled.img`
+  width: inherit;
+  height: inherit;
+  object-fit: cover;
+  background-color: var(--light-gray);
+`;
+
+interface CardImageProps {
+  img: Image;
+  width?: string;
+  height?: string;
+}
+
+const CardImage: React.FC<CardImageProps> = ({img, width, height}) => (
+  <CardContainer width={width} height={height}>
+    <StyledCardImage src={img.url} alt={img.alt || 'Card Image'} />
+  </CardContainer>
+);
+
+export default CardImage;

--- a/web/src/components/common/CardImage.tsx
+++ b/web/src/components/common/CardImage.tsx
@@ -45,6 +45,9 @@ interface CardImageProps {
   height?: string;
 }
 
+/**
+ * Image component for cards.
+ */
 const CardImage: React.FC<CardImageProps> = ({img, width, height}) => (
   <ImageContainer width={width} height={height}>
     <StyledCardImage src={img.url} alt={img.alt || 'Card Image'} />

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -24,12 +24,6 @@ import ListingPrice from 'components/common/ListingPrice';
 const CardContent = styled.div`
   display: flex;
   flex-direction: column;
-
-  padding: 0.8em;
-
-  & > * {
-    margin: 0;
-  }
 `;
 
 const Date = styled.span`

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -48,6 +48,10 @@ interface ListingCardProps {
   horizontal?: boolean;
 }
 
+/**
+ * Listing card component that displays basic listing details.
+ * Can be either horizontal or vertical.
+ */
 const ListingCard: React.FC<ListingCardProps> = ({
   listingName,
   price,

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -16,10 +16,9 @@
 
 import React from 'react';
 
-import styled from 'styled-components';
-
 import Card from 'components/common/Card';
 import ListingPrice from 'components/common/ListingPrice';
+import styled from 'styled-components';
 
 const CardContent = styled.div`
   display: flex;

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+import Card from 'components/common/Card';
+import ListingPrice from 'components/common/ListingPrice';
+
+const CardContent = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding: 0.8em;
+
+  & > * {
+    margin: 0;
+  }
+`;
+
+const Date = styled.span`
+  display: flex;
+  justify-content: flex-end;
+
+  font-size: 0.8rem;
+  color: var(--red);
+`;
+
+const ListingName = styled.span`
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--gray);
+`;
+
+interface ListingCardProps {
+  listingName: string;
+  price: number;
+  oldPrice: number;
+  endDate: string;
+  imgUrl: string;
+  horizontal?: boolean;
+}
+
+const ListingCard: React.FC<ListingCardProps> = ({
+  listingName,
+  price,
+  oldPrice,
+  imgUrl,
+  endDate,
+  horizontal,
+  children,
+}) => (
+  <Card
+    img={{
+      url: imgUrl,
+      alt: `Image of ${listingName}`,
+    }}
+    imgLeft={horizontal}
+  >
+    <CardContent>
+      <Date>{endDate}</Date>
+      <ListingName>{listingName}</ListingName>
+      <ListingPrice price={price} oldPrice={oldPrice} />
+      {children}
+    </CardContent>
+  </Card>
+);
+
+export default ListingCard;

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -66,7 +66,7 @@ const ListingCard: React.FC<ListingCardProps> = ({
       url: imgUrl,
       alt: `Image of ${listingName}`,
     }}
-    imgLeft={horizontal}
+    horizontal={horizontal}
   >
     <CardContent>
       <Date>{endDate}</Date>

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -36,7 +36,7 @@ const Date = styled.span`
 const ListingName = styled.span`
   font-size: 0.8rem;
   text-transform: uppercase;
-  color: var(--gray);
+  color: var(--dark-gray);
 `;
 
 interface ListingCardProps {

--- a/web/src/components/common/ListingPrice.tsx
+++ b/web/src/components/common/ListingPrice.tsx
@@ -39,6 +39,9 @@ interface ListingPriceProps {
   oldPrice?: number;
 }
 
+/**
+ * Listing price component that shows the current price and its previous price.
+ */
 const ListingPrice: React.FC<ListingPriceProps> = ({price, oldPrice}) => (
   <PriceContainer>
     <Price>${price}</Price>

--- a/web/src/components/common/ListingPrice.tsx
+++ b/web/src/components/common/ListingPrice.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+const PriceContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+const Price = styled.div`
+  font-size: 1.5rem;
+  padding-right: 5px;
+`;
+
+const OldPrice = styled.div`
+  font-size: 0.8rem;
+  text-decoration: line-through;
+`;
+
+interface ListingPriceProps {
+  price: number;
+  oldPrice?: number;
+}
+
+const ListingPrice: React.FC<ListingPriceProps> = ({price, oldPrice}) => (
+  <PriceContainer>
+    <Price>${price}</Price>
+    {oldPrice && <OldPrice>was: ${oldPrice}</OldPrice>}
+  </PriceContainer>
+);
+
+export default ListingPrice;

--- a/web/src/components/common/StrippedCol.tsx
+++ b/web/src/components/common/StrippedCol.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+import Col from 'muicss/lib/react/col';
+
+const StrippedCol = styled(Col)`
+  padding: 0;
+`;
+
+export default StrippedCol;

--- a/web/src/components/common/StrippedCol.tsx
+++ b/web/src/components/common/StrippedCol.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import styled from 'styled-components';
 import Col from 'muicss/lib/react/col';
+import styled from 'styled-components';
 
 const StrippedCol = styled(Col)`
   padding: 0;

--- a/web/src/components/common/StrippedCol.tsx
+++ b/web/src/components/common/StrippedCol.tsx
@@ -17,6 +17,9 @@
 import Col from 'muicss/lib/react/col';
 import styled from 'styled-components';
 
+/**
+ * Column component with no padding.
+ */
 const StrippedCol = styled(Col)`
   padding: 0;
 `;

--- a/web/src/components/design-samples/index.tsx
+++ b/web/src/components/design-samples/index.tsx
@@ -16,11 +16,10 @@
 
 import React from 'react';
 
-import Container from 'muicss/lib/react/container';
-
 import Card from 'components/common/Card';
-import StrippedCol from 'components/common/StrippedCol';
 import ListingCard from 'components/common/ListingCard';
+import StrippedCol from 'components/common/StrippedCol';
+import Container from 'muicss/lib/react/container';
 
 const SAMPLE_IMG_URL = 'https://picsum.photos/seed/picsum/200/300';
 
@@ -35,7 +34,8 @@ const DesignSamplesPage: React.FC = () => (
           alt: 'Random Image',
         }}
       >
-        Card with image on top. Risus quis varius quam quisque id diam vel quam elementum pulvinar etiam.
+        Card with image on top. Risus quis varius quam quisque id diam vel quam
+        elementum pulvinar etiam.
       </Card>
     </StrippedCol>
     <StrippedCol xs={6}>
@@ -69,14 +69,14 @@ const DesignSamplesPage: React.FC = () => (
         }}
         imgLeft
       >
-        Card with image on left. Risus quis varius quam quisque id diam vel quam elementum pulvinar etiam
-        non quam lacus est pellentesque elit.
+        Card with image on left. Risus quis varius quam quisque id diam vel quam
+        elementum pulvinar etiam non quam lacus est pellentesque elit.
       </Card>
     </StrippedCol>
     <StrippedCol xs={12}>
       <Card>
-        Card with no image. Risus quis varius quam quisque id diam vel quam elementum pulvinar etiam
-        non quam lacus est pellentesque elit.
+        Card with no image. Risus quis varius quam quisque id diam vel quam
+        elementum pulvinar etiam non quam lacus est pellentesque elit.
       </Card>
     </StrippedCol>
   </Container>

--- a/web/src/components/design-samples/index.tsx
+++ b/web/src/components/design-samples/index.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import Container from 'muicss/lib/react/container';
+
+import Card from 'components/common/Card';
+import StrippedCol from 'components/common/StrippedCol';
+import ListingCard from 'components/common/ListingCard';
+
+const SAMPLE_IMG_URL = 'https://picsum.photos/seed/picsum/200/300';
+
+const DesignSamplesPage: React.FC = () => (
+  <Container>
+    <h1>Design Samples</h1>
+    <h2>Cards</h2>
+    <StrippedCol xs={6}>
+      <Card
+        img={{
+          url: SAMPLE_IMG_URL,
+          alt: 'Random Image',
+        }}
+      >
+        Card with image on top. Risus quis varius quam quisque id diam vel quam elementum pulvinar etiam.
+      </Card>
+    </StrippedCol>
+    <StrippedCol xs={6}>
+      <ListingCard
+        listingName="Some Listing"
+        price={85}
+        oldPrice={121}
+        endDate="2d Left"
+        imgUrl={SAMPLE_IMG_URL}
+      >
+        Progress bar here
+      </ListingCard>
+    </StrippedCol>
+    <StrippedCol xs={12}>
+      <ListingCard
+        listingName="Some Listing"
+        price={85}
+        oldPrice={121}
+        endDate="2d Left"
+        imgUrl={SAMPLE_IMG_URL}
+        horizontal
+      >
+        Progress bar here
+      </ListingCard>
+    </StrippedCol>
+    <StrippedCol xs={12}>
+      <Card
+        img={{
+          url: SAMPLE_IMG_URL,
+          alt: 'Random Image',
+        }}
+        imgLeft
+      >
+        Card with image on left. Risus quis varius quam quisque id diam vel quam elementum pulvinar etiam
+        non quam lacus est pellentesque elit.
+      </Card>
+    </StrippedCol>
+    <StrippedCol xs={12}>
+      <Card>
+        Card with no image. Risus quis varius quam quisque id diam vel quam elementum pulvinar etiam
+        non quam lacus est pellentesque elit.
+      </Card>
+    </StrippedCol>
+  </Container>
+);
+
+export default DesignSamplesPage;

--- a/web/src/components/design-samples/index.tsx
+++ b/web/src/components/design-samples/index.tsx
@@ -67,7 +67,7 @@ const DesignSamplesPage: React.FC = () => (
           url: SAMPLE_IMG_URL,
           alt: 'Random Image',
         }}
-        imgLeft
+        horizontal
       >
         Card with image on left. Risus quis varius quam quisque id diam vel quam
         elementum pulvinar etiam non quam lacus est pellentesque elit.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -15,6 +15,7 @@
  */
 
 @import url('https://fonts.googleapis.com/css?family=Poppins&display=swap');
+@import url("//cdn.muicss.com/mui-0.10.1/css/mui.min.css");
 
 :root {
   /* brand colors */
@@ -24,8 +25,9 @@
   --bright-red: #EB5757;
   --red: #DB4437;
   --pale-gray: #EFEFEF;
-  --light-gray: #BDBDBD;
-  --gray: #A0A0A0;
+  --pale-gray: #BDBDBD;
+  --light-gray: #A0A0A0;
+  --gray: #3C3C3C;
   --dark-gray: #444444;
 
   /* brand fonts */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -25,9 +25,8 @@
   --bright-red: #EB5757;
   --red: #DB4437;
   --pale-gray: #EFEFEF;
-  --pale-gray: #BDBDBD;
-  --light-gray: #A0A0A0;
-  --gray: #3C3C3C;
+  --light-gray: #BDBDBD;
+  --gray: #A0A0A0;
   --dark-gray: #444444;
 
   /* brand fonts */

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -1,0 +1,4 @@
+export interface Image {
+  url: string;
+  alt?: string;
+}


### PR DESCRIPTION
## What's in this PR

![Screenshot 2020-06-18 at 2 26 41 PM](https://user-images.githubusercontent.com/25261058/84986168-aa4f5200-b170-11ea-982a-b256dc41c67e.png)

- Added Card and ListingCard components, as well as smaller components used to build it.
- Added a temporary `/design-samples` endpoint for us to place our component designs there for testing and previewing before they are added into the app. Will be removed or kept as a dev env only endpoint in the future.

## How to test

Currently built for mobile view so it will look really stretched and ugly if you don't change it to mobile view haha.

### Test on prod

Because I deployed it haha
[https://gpay-group-buy.an.r.appspot.com/design-samples](https://gpay-group-buy.an.r.appspot.com/design-samples)

OR

### Test locally

Fetch branch then
```
cd web
yarn
yarn start
```
And then navigate to `http://localhost:3000/design-samples` and you should see the page in the screenshot above :) 