### PR TITLE
Add stop handler on termination signals

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -68,7 +68,7 @@ app.use(
 const port = process.env.PORT || 5000;
 app.listen(port, () => console.log(`Listening on port ${port}`));
 
-const stopHandler = () => process.exit(1);
+const stopHandler = () => process.exit(1); // eslint-disable-line no-process-exit
 
 process.on('SIGTERM', stopHandler);
 process.on('SIGINT', stopHandler);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -66,5 +66,10 @@ app.use(
 );
 
 const port = process.env.PORT || 5000;
-app.listen(port);
-console.log(`Listening on port ${port}`);
+app.listen(port, () => console.log(`Listening on port ${port}`));
+
+const stopHandler = () => process.exit(1);
+
+process.on('SIGTERM', stopHandler);
+process.on('SIGINT', stopHandler);
+process.on('SIGHUP', stopHandler);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -68,8 +68,12 @@ app.use(
 const port = process.env.PORT || 5000;
 app.listen(port, () => console.log(`Listening on port ${port}`));
 
-const stopHandler = () => process.exit(1); // eslint-disable-line no-process-exit
+const onStopSignal = () => {
+  console.log('Termination signal received, exiting process..');
+  process.exit(1); // eslint-disable-line no-process-exit
+};
 
-process.on('SIGTERM', stopHandler);
-process.on('SIGINT', stopHandler);
-process.on('SIGHUP', stopHandler);
+process.on('SIGTERM', onStopSignal);
+process.on('SIGINT', onStopSignal);
+process.on('SIGHUP', onStopSignal);
+process.on('SIGUSR2', onStopSignal); // Nodemon uses this


### PR DESCRIPTION
Force processes to be killed because previously we kept getting errors like:
```
Error: listen EADDRINUSE: address already in use :::5000
...
[nodemon] app crashed - waiting for file changes before starting...
```