### PR TITLE
Remove unused merchant operations

### DIFF
--- a/server/src/api/merchants.ts
+++ b/server/src/api/merchants.ts
@@ -16,7 +16,6 @@
 
 /**
  * @fileoverview Handles routing of /merchants endpoints.
- * @author Karen Frilya Celine
  */
 
 import express from 'express';
@@ -24,21 +23,5 @@ import express from 'express';
 import {merchantService} from '../services';
 
 const router: express.Router = express.Router();
-
-router.get(
-  '/',
-  async (
-    req: express.Request,
-    res: express.Response,
-    next: express.NextFunction
-  ) => {
-    try {
-      const merchants = await merchantService.getAllMerchants();
-      res.send(merchants);
-    } catch (error) {
-      return next(error);
-    }
-  }
-);
 
 export const merchantRouter: express.Router = router;

--- a/server/src/services/merchants.ts
+++ b/server/src/services/merchants.ts
@@ -14,10 +14,4 @@
  * limitations under the License.
  */
 
-import {merchantStorage} from '../storage';
-
-const getAllMerchants = async () => await merchantStorage.getAllMerchants();
-
-export const merchantService = {
-  getAllMerchants,
-};
+export const merchantService = {};

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -17,36 +17,6 @@
 /**
  * @fileoverview This file contains the database operations related to Merchant
  * entities.
- * @author Karen Frilya Celine
  */
 
-import {Datastore} from '@google-cloud/datastore';
-import {Guid} from 'guid-typescript';
-
-import {MERCHANT_KIND} from '../constants/kinds';
-
-const datastore = new Datastore();
-
-async function getAllMerchants() {
-  const query = datastore.createQuery(MERCHANT_KIND);
-  const [merchants, info] = await datastore.runQuery(query);
-  return merchants;
-}
-
-async function getMerchant(merchantId: string) {
-  const key = datastore.key([MERCHANT_KIND, merchantId]);
-  return await datastore.get(key);
-}
-
-async function addMerchant(merchant: object) {
-  return await datastore.insert({
-    key: datastore.key([MERCHANT_KIND, Guid.raw()]),
-    data: merchant,
-  });
-}
-
-export const merchantStorage = {
-  getAllMerchants,
-  getMerchant,
-  addMerchant,
-};
+export const merchantStorage = {};


### PR DESCRIPTION
Previously, I added these codes to setup project structure.
But these are not used yet and are not standardised with getCustomer operations which have better style/structure.
So, I am removing these.