### PR TITLE
Add numCommits to get customer response

### DIFF
--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -27,10 +27,11 @@ const customerRouter = Router();
 customerRouter.get(
   '/:customerId',
   async (req: Request, res: Response, next: NextFunction) => {
-    const {customerId} = req.params;
+    const {customerIdStr} = req.params;
+    const customerId = Number(customerIdStr);
 
     try {
-      const customer = await customerService.getCustomer(Number(customerId));
+      const customer = await customerService.getCustomer(customerId);
       res.send(customer);
     } catch (error) {
       return next(error);

--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -27,7 +27,7 @@ const customerRouter = Router();
 customerRouter.get(
   '/:customerId',
   async (req: Request, res: Response, next: NextFunction) => {
-    const {customerIdStr} = req.params;
+    const {customerId: customerIdStr} = req.params;
     const customerId = Number(customerIdStr);
 
     try {

--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -30,7 +30,7 @@ customerRouter.get(
     const {customerId} = req.params;
 
     try {
-      const customer = await customerService.getCustomer(customerId);
+      const customer = await customerService.getCustomer(Number(customerId));
       res.send(customer);
     } catch (error) {
       return next(error);

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -44,9 +44,9 @@ export type CommitStatus =
   | 'unsuccessful';
 
 /**
-* ListingPayload Interface that contains the fields of the payload that
-* would be sent to create a Listing Entity.
-*/
+ * ListingPayload Interface that contains the fields of the payload that
+ * would be sent to create a Listing Entity.
+ */
 export interface CommitPayload {
   customerId: number;
   listingId: number;

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -30,7 +30,7 @@ export interface CustomerPayload {
  */
 export interface CustomerResponse extends CustomerPayload {
   id: number;
-  numCommits: number;
+  numOngoingCommits: number;
 }
 
 /**

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -44,7 +44,7 @@ export type CommitStatus =
   | 'unsuccessful';
 
 /**
- * ListingPayload Interface that contains the fields of the payload that
+ * CommitPayload Interface that contains the fields of the payload that
  * would be sent to create a Listing Entity.
  */
 export interface CommitPayload {
@@ -55,7 +55,7 @@ export interface CommitPayload {
 }
 
 /**
- * ListingResponse Interface that contains the fields of the Response that
+ * CommitResponse Interface that contains the fields of the Response that
  * client side would receive.
  */
 export interface CommitResponse extends CommitPayload {

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -15,11 +15,6 @@
  */
 
 /**
- * ResponseId type is the union.type of datastore's built-in id.
- */
-export type ResponseId = number | Long | string | null;
-
-/**
  * CustomerPayload Interface that contains the fields of the payload that
  * would be sent to create a Customer Entity.
  */
@@ -34,6 +29,36 @@ export interface CustomerPayload {
  * client side would receive.
  */
 export interface CustomerResponse extends CustomerPayload {
+  id: number;
+  numCommits: number;
+}
+
+/**
+ * CommitStatus type contains the different states of a Commit.
+ */
+export type CommitStatus =
+  | 'ongoing'
+  | 'successful'
+  | 'paid'
+  | 'completed'
+  | 'unsuccessful';
+
+/**
+* ListingPayload Interface that contains the fields of the payload that
+* would be sent to create a Listing Entity.
+*/
+export interface CommitPayload {
+  customerId: number;
+  listingId: number;
+  createdAt: string;
+  commitStatus: CommitStatus;
+}
+
+/**
+ * ListingResponse Interface that contains the fields of the Response that
+ * client side would receive.
+ */
+export interface CommitResponse extends CommitPayload {
   id: number;
 }
 

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -50,7 +50,7 @@ export type CommitStatus =
 export interface CommitPayload {
   customerId: number;
   listingId: number;
-  createdAt: string;
+  createdAt: Date;
   commitStatus: CommitStatus;
 }
 

--- a/server/src/services/customers.ts
+++ b/server/src/services/customers.ts
@@ -17,7 +17,7 @@
 import {CustomerResponse} from '../interfaces';
 import {customerStorage} from '../storage';
 
-const getCustomer = async (customerId: string): Promise<CustomerResponse> =>
+const getCustomer = async (customerId: number): Promise<CustomerResponse> =>
   await customerStorage.getCustomer(customerId);
 
 export default {getCustomer};

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -18,12 +18,12 @@ import {CUSTOMER_KIND, COMMIT_KIND} from '../constants/kinds';
 import {CustomerResponse, CommitResponse} from '../interfaces';
 import {getWithId, getAllWithId} from './datastore';
 
-const getCustomer = async (customerId: string): Promise<CustomerResponse> => {
+const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
   const customer = await getWithId(CUSTOMER_KIND, customerId);
   const commits: CommitResponse[] = await getAllWithId(COMMIT_KIND, [
     {
       property: 'customerId',
-      value: 5634161670881280,
+      value: customerId,
     },
     {
       property: 'commitStatus',

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -16,11 +16,11 @@
 
 import {CUSTOMER_KIND, COMMIT_KIND} from '../constants/kinds';
 import {CustomerResponse, CommitResponse} from '../interfaces';
-import {getWithId, getAllWithId} from './datastore';
+import {get, getAll} from './datastore';
 
 const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
-  const customer = await getWithId(CUSTOMER_KIND, customerId);
-  const commits: CommitResponse[] = await getAllWithId(COMMIT_KIND, [
+  const customer = await get(CUSTOMER_KIND, customerId);
+  const commits: CommitResponse[] = await getAll(COMMIT_KIND, [
     {
       property: 'customerId',
       value: customerId,

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -33,7 +33,7 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
 
   return {
     ...customer,
-    numCommits: commits.length,
+    numOngoingCommits: commits.length,
   };
 };
 

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -35,6 +35,6 @@ const getCustomer = async (customerId: string): Promise<CustomerResponse> => {
     ...customer,
     numCommits: commits.length,
   };
-}
+};
 
 export default {getCustomer};

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -14,11 +14,27 @@
  * limitations under the License.
  */
 
-import {CUSTOMER_KIND} from '../constants/kinds';
-import {CustomerResponse} from '../interfaces';
-import {getWithId} from './datastore';
+import {CUSTOMER_KIND, COMMIT_KIND} from '../constants/kinds';
+import {CustomerResponse, CommitResponse} from '../interfaces';
+import {getWithId, getAllWithId} from './datastore';
 
-const getCustomer = async (customerId: string): Promise<CustomerResponse> =>
-  getWithId(CUSTOMER_KIND, customerId);
+const getCustomer = async (customerId: string): Promise<CustomerResponse> => {
+  const customer = await getWithId(CUSTOMER_KIND, customerId);
+  const commits: CommitResponse[] = await getAllWithId(COMMIT_KIND, [
+    {
+      property: 'customerId',
+      value: 5634161670881280,
+    },
+    {
+      property: 'commitStatus',
+      value: 'ongoing',
+    },
+  ]);
+
+  return {
+    ...customer,
+    numCommits: commits.length,
+  };
+}
 
 export default {getCustomer};

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -18,7 +18,7 @@ import {Datastore} from '@google-cloud/datastore';
 import {google} from '@google-cloud/datastore/build/protos/protos';
 import {Entity} from '@google-cloud/datastore/build/src/entity';
 
-import {ResponseId} from '../interfaces';
+import {Filter, ResponseId} from './interfaces';
 
 const datastore = new Datastore();
 
@@ -50,9 +50,16 @@ const getWithId = async (kind: string, id: string) => {
 /**
  * A Datastore wrapper that gets all entities of a specified Kind.
  * @param kind The Kind that is being queried
+ * @param filters Any filters that will be applied to the query
  */
-const getAllWithId = async (kind: string) => {
-  const query = datastore.createQuery(kind);
+const getAllWithId = async (kind: string, filters?: Filter[]) => {
+  let query = datastore.createQuery(kind);
+  if (filters) {
+    filters.forEach((filter) => {
+      query = query.filter(filter.property, filter.value)
+    });
+  }
+
   const [res] = await datastore.runQuery(query);
   const resWithId = res.map(item => extractAndAppendId(item));
   return resWithId;

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -41,8 +41,8 @@ const extractAndAppendId = (res: Entity) => {
  * @param kind The Kind that is being queried
  * @param id The id of the Entity being queried
  */
-const getWithId = async (kind: string, id: string) => {
-  const key = datastore.key([kind, datastore.int(id)]);
+const getWithId = async (kind: string, id: number) => {
+  const key = datastore.key([kind, id]);
   const [res] = await datastore.get(key);
   return extractAndAppendId(res);
 };

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -55,8 +55,8 @@ const getWithId = async (kind: string, id: string) => {
 const getAllWithId = async (kind: string, filters?: Filter[]) => {
   let query = datastore.createQuery(kind);
   if (filters) {
-    filters.forEach((filter) => {
-      query = query.filter(filter.property, filter.value)
+    filters.forEach(filter => {
+      query = query.filter(filter.property, filter.value);
     });
   }
 

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -95,4 +95,4 @@ const add = async (kind: string, data: object): Promise<number> => {
   return Number(id);
 };
 
-export { get, getAll, add};
+export {get, getAll, add};

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -54,11 +54,9 @@ const getWithId = async (kind: string, id: number) => {
  */
 const getAllWithId = async (kind: string, filters?: Filter[]) => {
   let query = datastore.createQuery(kind);
-  if (filters) {
-    filters.forEach(filter => {
-      query = query.filter(filter.property, filter.value);
-    });
-  }
+  filters?.forEach(filter => {
+    query = query.filter(filter.property, filter.value);
+  });
 
   const [res] = await datastore.runQuery(query);
   const resWithId = res.map(item => extractAndAppendId(item));

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -41,7 +41,7 @@ const extractAndAppendId = (res: Entity) => {
  * @param kind The Kind that is being queried
  * @param id The id of the Entity being queried
  */
-const getWithId = async (kind: string, id: number) => {
+const get = async (kind: string, id: number) => {
   const key = datastore.key([kind, id]);
   const [res] = await datastore.get(key);
   return extractAndAppendId(res);
@@ -52,7 +52,7 @@ const getWithId = async (kind: string, id: number) => {
  * @param kind The Kind that is being queried
  * @param filters Any filters that will be applied to the query
  */
-const getAllWithId = async (kind: string, filters?: Filter[]) => {
+const getAll = async (kind: string, filters?: Filter[]) => {
   let query = datastore.createQuery(kind);
   filters?.forEach(filter => {
     query = query.filter(filter.property, filter.value);
@@ -95,4 +95,4 @@ const add = async (kind: string, data: object): Promise<number> => {
   return Number(id);
 };
 
-export {getWithId, getAllWithId, add};
+export { get, getAll, add};

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+* ResponseId type is the union type of datastore's built-in id.
+*/
+export type ResponseId = number | Long | string | null;
+
+/**
+ * Filter Interface that contains the fields of the payload that
+ * would be sent to create a Customer Entity.
+ */
+export interface Filter {
+  property: string;
+  value: any;
+}

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -20,8 +20,7 @@
 export type ResponseId = number | Long | string | null;
 
 /**
- * Filter Interface that contains the fields of the payload that
- * would be sent to create a Customer Entity.
+ * Filter Interface that contains the fields of a filter query for datastore.
  */
 export interface Filter {
   property: string;

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -15,8 +15,8 @@
  */
 
 /**
-* ResponseId type is the union type of datastore's built-in id.
-*/
+ * ResponseId type is the union type of datastore's built-in id.
+ */
 export type ResponseId = number | Long | string | null;
 
 /**

--- a/server/src/storage/listings.ts
+++ b/server/src/storage/listings.ts
@@ -17,9 +17,9 @@
 import {ListingResponse} from 'interfaces';
 
 import {LISTING_KIND} from '../constants/kinds';
-import {getAllWithId} from './datastore';
+import {getAll} from './datastore';
 
 const getAllListings = async (): Promise<ListingResponse[]> =>
-  getAllWithId(LISTING_KIND);
+    getAll(LISTING_KIND);
 
 export default {getAllListings};

--- a/server/src/storage/listings.ts
+++ b/server/src/storage/listings.ts
@@ -20,6 +20,6 @@ import {LISTING_KIND} from '../constants/kinds';
 import {getAll} from './datastore';
 
 const getAllListings = async (): Promise<ListingResponse[]> =>
-    getAll(LISTING_KIND);
+  getAll(LISTING_KIND);
 
 export default {getAllListings};


### PR DESCRIPTION
## Changes
- Added numCommits to customer getter response. Num commits is retrieved by querying `Commits` and filtering by customerId and listingStatus

## How to test
Fetch my branch
```
cd server
yarn
yarn start:dev
```
Make a request to `http://localhost:5000/customers/5634161670881280` (our dear customer) and there will be a new `numCommits` field added. Our dear customer here should have 1 commit.