### PR TITLE
Lazy load ListingCard instead of CardImage

### DIFF
--- a/web/src/components/common/CardImage.tsx
+++ b/web/src/components/common/CardImage.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 
-import LazyWrapper from 'components/common/LazyWrapper';
 import {Image} from 'interfaces';
 import styled from 'styled-components';
 
@@ -50,11 +49,9 @@ interface CardImageProps {
  * Image component for cards.
  */
 const CardImage: React.FC<CardImageProps> = ({img, width, height}) => (
-  <LazyWrapper>
-    <ImageContainer width={width} height={height}>
-      <StyledCardImage src={img.url} alt={img.alt || 'Card Image'} />
-    </ImageContainer>
-  </LazyWrapper>
+  <ImageContainer width={width} height={height}>
+    <StyledCardImage src={img.url} alt={img.alt || 'Card Image'} />
+  </ImageContainer>
 );
 
 export default CardImage;

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import Card from 'components/common/Card';
+import LazyWrapper from 'components/common/LazyWrapper';
 import ListingPrice from 'components/common/ListingPrice';
 import styled from 'styled-components';
 
@@ -61,20 +62,22 @@ const ListingCard: React.FC<ListingCardProps> = ({
   horizontal,
   children,
 }) => (
-  <Card
-    img={{
-      url: imgUrl,
-      alt: `Image of ${listingName}`,
-    }}
-    horizontal={horizontal}
-  >
-    <CardContent>
-      <Date>{endDate}</Date>
-      <ListingName>{listingName}</ListingName>
-      <ListingPrice price={price} oldPrice={oldPrice} />
-      {children}
-    </CardContent>
-  </Card>
+  <LazyWrapper>
+    <Card
+      img={{
+        url: imgUrl,
+        alt: `Image of ${listingName}`,
+      }}
+      horizontal={horizontal}
+    >
+      <CardContent>
+        <Date>{endDate}</Date>
+        <ListingName>{listingName}</ListingName>
+        <ListingPrice price={price} oldPrice={oldPrice} />
+        {children}
+      </CardContent>
+    </Card>
+  </LazyWrapper>
 );
 
 export default ListingCard;


### PR DESCRIPTION
# Changes
Instead of wrapping `CardImage` with `LazyWrapper`, lazy load the entire `ListingCard` instead.
The loading of image after the rest of the card component causes the horizontal mode of `ListingCard` to not work as intended.

**Before:**
![Screenshot 2020-06-24 at 7 44 48 PM](https://user-images.githubusercontent.com/25261058/85550225-556d7900-b653-11ea-8fb8-63586ef748b3.png)
**After:**
![Screenshot 2020-06-24 at 7 43 52 PM](https://user-images.githubusercontent.com/25261058/85550232-569ea600-b653-11ea-90a7-8a9248be75b5.png)
