### PR TITLE
Add listing details page

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -22,12 +22,11 @@ import {Switch, Route} from 'react-router-dom';
 
 // Customer Pages
 const CustomerExplorePage = lazy(() => import('components/customer/explore'));
-const CustomerListingDetailsPage = lazy(() =>
-  import('components/customer/listing-details')
-);
 // Merchant Pages
 const MerchantLandingPage = lazy(() => import('components/merchant/landing'));
 const MerchantSignUpPage = lazy(() => import('components/merchant/sign-up'));
+// Shared Pages
+const ListingDetailsPage = lazy(() => import('components/listing-details'));
 // Design samples
 const DesignSamplesPage = lazy(() => import('components/design-samples'));
 
@@ -36,10 +35,7 @@ const Routes: React.FC = () => (
     <Switch>
       <CustomerCommitCountProvider>
         <Route exact path="/" component={CustomerExplorePage} />
-        <Route
-          path="/listing/:listingId"
-          component={CustomerListingDetailsPage}
-        />
+        <Route path="/listing/:listingId" component={ListingDetailsPage} />
       </CustomerCommitCountProvider>
       <Route exact path="/merchant" component={MerchantLandingPage} />
       <Route exact path="/merchant/sign-up" component={MerchantSignUpPage} />

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -25,7 +25,7 @@ const CustomerExplorePage = lazy(() => import('components/customer/explore'));
 // Merchant Pages
 const MerchantLandingPage = lazy(() => import('components/merchant/landing'));
 const MerchantSignUpPage = lazy(() => import('components/merchant/sign-up'));
-// Shared Pages
+// Common Pages
 const ListingDetailsPage = lazy(() => import('components/listing-details'));
 // Design samples
 const DesignSamplesPage = lazy(() => import('components/design-samples'));
@@ -40,9 +40,6 @@ const Routes: React.FC = () => (
       <Route exact path="/merchant" component={MerchantLandingPage} />
       <Route exact path="/merchant/sign-up" component={MerchantSignUpPage} />
       <Route exact path="/design-samples" component={DesignSamplesPage} />
-      <CustomerCommitCountProvider>
-        <Route exact path="/" component={CustomerExplorePage} />
-      </CustomerCommitCountProvider>
     </Switch>
   </Suspense>
 );

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -22,6 +22,9 @@ import {Switch, Route} from 'react-router-dom';
 
 // Customer Pages
 const CustomerExplorePage = lazy(() => import('components/customer/explore'));
+const CustomerListingDetailsPage = lazy(() =>
+  import('components/customer/listing-details')
+);
 // Merchant Pages
 const MerchantLandingPage = lazy(() => import('components/merchant/landing'));
 const MerchantSignUpPage = lazy(() => import('components/merchant/sign-up'));
@@ -31,6 +34,13 @@ const DesignSamplesPage = lazy(() => import('components/design-samples'));
 const Routes: React.FC = () => (
   <Suspense fallback={<Loading />}>
     <Switch>
+      <CustomerCommitCountProvider>
+        <Route exact path="/" component={CustomerExplorePage} />
+        <Route
+          path="/listing/:listingId"
+          component={CustomerListingDetailsPage}
+        />
+      </CustomerCommitCountProvider>
       <Route exact path="/merchant" component={MerchantLandingPage} />
       <Route exact path="/merchant/sign-up" component={MerchantSignUpPage} />
       <Route exact path="/design-samples" component={DesignSamplesPage} />

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -18,6 +18,7 @@ import {Customer, Listing} from 'interfaces';
 
 /**
  * Fetches a particular customer with the specified customerId.
+ * @param customerId Id of the customer to retrieve
  */
 export const getCustomer = async (customerId: number): Promise<Customer> => {
   const res = await fetch(
@@ -31,5 +32,16 @@ export const getCustomer = async (customerId: number): Promise<Customer> => {
  */
 export const getAllListings = async (): Promise<Listing[]> => {
   const res = await fetch(`${process.env.REACT_APP_SERVER_URL}/listings`);
+  return res.json();
+};
+
+/**
+ * Fetches a particular listing with the specified customerId.
+ * @param listingId Id of the listing to retrieve
+ */
+export const getListing = async (listingId: number): Promise<Listing> => {
+  const res = await fetch(
+    `${process.env.REACT_APP_SERVER_URL}/listings/${listingId}`
+  );
   return res.json();
 };

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -36,7 +36,7 @@ export const getAllListings = async (): Promise<Listing[]> => {
 };
 
 /**
- * Fetches a particular listing with the specified customerId.
+ * Fetches a particular listing with the specified listingId.
  * @param listingId Id of the listing to retrieve
  */
 export const getListing = async (listingId: number): Promise<Listing> => {

--- a/web/src/components/common/BackButton.tsx
+++ b/web/src/components/common/BackButton.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import Button from 'muicss/lib/react/button';
 import { ChevronLeft } from 'react-feather';
 import styled, { css } from 'styled-components';
+import { ButtonProps } from 'muicss/react';
 
 type PosType = 'absolute' | 'static';
 
@@ -63,15 +64,15 @@ const StyledBackButton = styled(Button)`
   /* stylelint-enable value-keyword-case */
 `;
 
-interface BackButtonProps {
+interface BackButtonProps extends ButtonProps {
   pos?: PosType;
 }
 
 /**
  * BackButton component with either static or absolute position.
  */
-const BackButton: React.FC<BackButtonProps> = ({ pos = 'static' }) => (
-  <StyledBackButton variant="flat" pos={pos}>
+const BackButton: React.FC<BackButtonProps> = ({ pos = 'static', ...buttonProps }) => (
+  <StyledBackButton variant="flat" pos={pos} {...buttonProps}>
     <ChevronLeft />
     Back
   </StyledBackButton>

--- a/web/src/components/common/BackButton.tsx
+++ b/web/src/components/common/BackButton.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import Button from 'muicss/lib/react/button';
+import { ChevronLeft } from 'react-feather';
+import styled, { css } from 'styled-components';
+
+type PosType = 'absolute' | 'static';
+
+const AbsolutePosStyle = css`
+  position: absolute;
+  top: 15px;
+  left: 0px;
+  z-index: 999; /* Ensure always on top */
+`;
+
+const StaticPosStyle = css``;
+
+interface CommitsBadgeProps {
+  pos?: PosType;
+}
+
+const StyledBackButton = styled(Button)`
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+
+  padding-left: 15px;
+  border-radius: 0 999px 999px 0; /* Ensure pill shape on right end */
+
+  && {
+    background: var(--green);
+    color: white;
+
+    :focus {
+      background: var(--green);
+      color: white;
+    }
+  }
+
+  /* stylelint-disable value-keyword-case */
+  ${({ pos }: CommitsBadgeProps) => {
+    switch (pos) {
+      case 'absolute':
+        return AbsolutePosStyle;
+      case 'static':
+        return StaticPosStyle;
+      default:
+        return StaticPosStyle;
+    }
+  }};
+  /* stylelint-enable value-keyword-case */
+`;
+
+interface BackButtonProps {
+  pos?: PosType;
+}
+
+/**
+ * BackButton component with either static or absolute position.
+ */
+const BackButton: React.FC<BackButtonProps> = ({ pos = 'static' }) => (
+  <StyledBackButton variant="flat" pos={pos}>
+    <ChevronLeft />
+    Back
+  </StyledBackButton>
+);
+
+export default BackButton;

--- a/web/src/components/common/BackButton.tsx
+++ b/web/src/components/common/BackButton.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 
 import Button from 'muicss/lib/react/button';
-import { ChevronLeft } from 'react-feather';
-import styled, { css } from 'styled-components';
-import { ButtonProps } from 'muicss/react';
+import {ButtonProps} from 'muicss/react';
+import {ChevronLeft} from 'react-feather';
+import styled, {css} from 'styled-components';
 
 type PosType = 'absolute' | 'static';
 
@@ -51,7 +51,7 @@ const StyledBackButton = styled(Button)`
   }
 
   /* stylelint-disable value-keyword-case */
-  ${({ pos }: BackButtonProps) => {
+  ${({pos}: BackButtonProps) => {
     switch (pos) {
       case 'absolute':
         return AbsolutePosStyle;
@@ -71,7 +71,10 @@ interface BackButtonProps extends ButtonProps {
 /**
  * BackButton component with either static or absolute position.
  */
-const BackButton: React.FC<BackButtonProps> = ({ pos = 'static', ...buttonProps }) => (
+const BackButton: React.FC<BackButtonProps> = ({
+  pos = 'static',
+  ...buttonProps
+}) => (
   <StyledBackButton variant="flat" pos={pos} {...buttonProps}>
     <ChevronLeft />
     Back

--- a/web/src/components/common/BackButton.tsx
+++ b/web/src/components/common/BackButton.tsx
@@ -26,7 +26,7 @@ type PosType = 'absolute' | 'static';
 const AbsolutePosStyle = css`
   position: absolute;
   top: 15px;
-  left: 0px;
+  left: 0;
   z-index: 999; /* Ensure always on top */
 `;
 

--- a/web/src/components/common/BackButton.tsx
+++ b/web/src/components/common/BackButton.tsx
@@ -31,10 +31,6 @@ const AbsolutePosStyle = css`
 
 const StaticPosStyle = css``;
 
-interface CommitsBadgeProps {
-  pos?: PosType;
-}
-
 const StyledBackButton = styled(Button)`
   display: flex;
   flex-flow: row;
@@ -54,7 +50,7 @@ const StyledBackButton = styled(Button)`
   }
 
   /* stylelint-disable value-keyword-case */
-  ${({ pos }: CommitsBadgeProps) => {
+  ${({ pos }: BackButtonProps) => {
     switch (pos) {
       case 'absolute':
         return AbsolutePosStyle;

--- a/web/src/components/common/CommitProgress.tsx
+++ b/web/src/components/common/CommitProgress.tsx
@@ -25,6 +25,7 @@ type CommitTextPos = 'none' | 'top' | 'bottom';
 
 interface CommitProgressContainerProps {
   textPos?: CommitTextPos;
+  largerFont?: boolean;
 }
 
 const CommitProgressContainer = styled.div`
@@ -39,8 +40,10 @@ const CommitProgressContainer = styled.div`
         return 'column';
     }
   }};
+
   text-align: right;
-  font-size: 0.8em;
+  font-size: ${({ largerFont }: CommitProgressContainerProps) =>
+    largerFont ? '1em' : '0.8em'};
 `;
 
 const StyledLine = styled(Line)`
@@ -60,6 +63,7 @@ interface CommitProgressProps {
   minCommits: number;
   textPos?: CommitTextPos;
   thicker?: boolean;
+  largerFont?: boolean;
 }
 
 /**
@@ -70,11 +74,12 @@ const CommitProgress: React.FC<CommitProgressProps> = ({
   numCommits,
   minCommits,
   textPos = 'bottom',
+  largerFont,
 }) => {
   const percent = Math.min(100, (numCommits / minCommits) * 100);
 
   return (
-    <CommitProgressContainer textPos={textPos}>
+    <CommitProgressContainer textPos={textPos} largerFont={largerFont} >
       {textPos !== 'none' && (
         <div>
           <span>Commiters: </span>

--- a/web/src/components/common/CommitProgress.tsx
+++ b/web/src/components/common/CommitProgress.tsx
@@ -42,7 +42,7 @@ const CommitProgressContainer = styled.div`
   }};
 
   text-align: right;
-  font-size: ${({ largerFont }: CommitProgressContainerProps) =>
+  font-size: ${({largerFont}: CommitProgressContainerProps) =>
     largerFont ? '1em' : '0.8em'};
 `;
 
@@ -79,7 +79,7 @@ const CommitProgress: React.FC<CommitProgressProps> = ({
   const percent = Math.min(100, (numCommits / minCommits) * 100);
 
   return (
-    <CommitProgressContainer textPos={textPos} largerFont={largerFont} >
+    <CommitProgressContainer textPos={textPos} largerFont={largerFont}>
       {textPos !== 'none' && (
         <div>
           <span>Commiters: </span>

--- a/web/src/components/common/DeadlineTag.tsx
+++ b/web/src/components/common/DeadlineTag.tsx
@@ -20,12 +20,17 @@ import {isPast} from 'date-fns';
 import styled from 'styled-components';
 import {formatDeadlineFromNowText} from 'utils/date';
 
+interface StyledDeadlineProps {
+  largerFont?: boolean;
+}
+
 const StyledDeadline = styled.span`
   display: flex;
   justify-content: flex-end;
 
   color: var(--dark-gray);
-  font-size: 0.9em;
+  font-size: ${({ largerFont }: StyledDeadlineProps) =>
+    largerFont ? '1em' : '0.9em'};
 `;
 
 const RedText = styled.span`
@@ -34,6 +39,7 @@ const RedText = styled.span`
 
 interface DeadlineTagProps {
   deadline: string;
+  largerFont?: boolean;
 }
 
 /**
@@ -42,11 +48,11 @@ interface DeadlineTagProps {
  * is not over.
  * Displays number of days since deadline if listing has ended.
  */
-const DeadlineTag: React.FC<DeadlineTagProps> = ({deadline}) => {
+const DeadlineTag: React.FC<DeadlineTagProps> = ({deadline, largerFont}) => {
   const deadlineDate = new Date(deadline);
   const tag = formatDeadlineFromNowText(deadlineDate);
   return (
-    <StyledDeadline>
+    <StyledDeadline largerFont={largerFont}>
       {isPast(deadlineDate) ? <>{tag}</> : <RedText>{tag}</RedText>}
     </StyledDeadline>
   );

--- a/web/src/components/common/DeadlineTag.tsx
+++ b/web/src/components/common/DeadlineTag.tsx
@@ -29,7 +29,7 @@ const StyledDeadline = styled.span`
   justify-content: flex-end;
 
   color: var(--dark-gray);
-  font-size: ${({ largerFont }: StyledDeadlineProps) =>
+  font-size: ${({largerFont}: StyledDeadlineProps) =>
     largerFont ? '1em' : '0.9em'};
 `;
 

--- a/web/src/components/common/ListingDescription.tsx
+++ b/web/src/components/common/ListingDescription.tsx
@@ -25,7 +25,11 @@ import CommitProgress from './CommitProgress';
 
 const Container = styled.div`
   & > * {
-    margin: 5px 0;
+    padding: 5px 0;
+
+    :first-child {
+      margin-top: 10px;
+    }
   }
 `;
 
@@ -37,6 +41,7 @@ const ListingName = styled.span`
 
 const Description = styled.p`
   color: var(--dark-gray);
+  margin: 0;
 `;
 
 interface ListingDescriptionProps {

--- a/web/src/components/common/ListingDescription.tsx
+++ b/web/src/components/common/ListingDescription.tsx
@@ -58,14 +58,15 @@ const ListingDescription: React.FC<ListingDescriptionProps> = ({
   },
 }) => (
   <Container>
-    <DeadlineTag deadline={deadline} />
+    <DeadlineTag deadline={deadline} largerFont />
     <ListingName>{name}</ListingName>
-    <ListingPrice price={price} oldPrice={oldPrice} />
+    <ListingPrice price={price} oldPrice={oldPrice} largerFont />
     <Description>{description}</Description>
     <CommitProgress
       minCommits={minCommits}
       numCommits={numCommits}
       textPos="top"
+      largerFont
     />
   </Container>
 );

--- a/web/src/components/common/ListingDescription.tsx
+++ b/web/src/components/common/ListingDescription.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import DeadlineTag from 'components/common/DeadlineTag';
+import ListingPrice from 'components/common/ListingPrice';
+import {Listing} from 'interfaces';
+import styled from 'styled-components';
+
+import CommitProgress from './CommitProgress';
+
+const Container = styled.div`
+  & > * {
+    margin: 5px 0;
+  }
+`;
+
+const ListingName = styled.span`
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: var(--dark-gray);
+`;
+
+const Description = styled.p`
+  color: var(--dark-gray);
+`;
+
+interface ListingDescriptionProps {
+  listing: Listing;
+}
+
+/**
+ * ListingDescription component that contains full listing description.
+ */
+const ListingDescription: React.FC<ListingDescriptionProps> = ({
+  listing: {
+    name,
+    price,
+    oldPrice,
+    deadline,
+    description,
+    numCommits,
+    minCommits,
+  },
+}) => (
+  <Container>
+    <DeadlineTag deadline={deadline} />
+    <ListingName>{name}</ListingName>
+    <ListingPrice price={price} oldPrice={oldPrice} />
+    <Description>{description}</Description>
+    <CommitProgress
+      minCommits={minCommits}
+      numCommits={numCommits}
+      textPos="top"
+    />
+  </Container>
+);
+
+export default ListingDescription;

--- a/web/src/components/common/ListingPrice.tsx
+++ b/web/src/components/common/ListingPrice.tsx
@@ -35,8 +35,7 @@ interface PriceProps {
 }
 
 const Price = styled.div`
-  font-size: ${({ largerFont }: PriceProps) =>
-    largerFont ? '2.3em' : '1.7em'};
+  font-size: ${({largerFont}: PriceProps) => (largerFont ? '2.3em' : '1.7em')};
   padding-right: 5px;
 `;
 
@@ -54,7 +53,11 @@ interface ListingPriceProps {
 /**
  * Listing price component that shows the current price and its previous price.
  */
-const ListingPrice: React.FC<ListingPriceProps> = ({price, oldPrice, largerFont}) => (
+const ListingPrice: React.FC<ListingPriceProps> = ({
+  price,
+  oldPrice,
+  largerFont,
+}) => (
   <PriceContainer>
     <Price largerFont={largerFont}>{formatMoney(price)}</Price>
     {oldPrice && <OldPrice>{formatMoney(oldPrice)}</OldPrice>}

--- a/web/src/components/common/ListingPrice.tsx
+++ b/web/src/components/common/ListingPrice.tsx
@@ -30,27 +30,33 @@ const PriceContainer = styled.div`
   }
 `;
 
+interface PriceProps {
+  largerFont?: boolean;
+}
+
 const Price = styled.div`
-  font-size: 1.5rem;
+  font-size: ${({ largerFont }: PriceProps) =>
+    largerFont ? '2.3em' : '1.7em'};
   padding-right: 5px;
 `;
 
 const OldPrice = styled.div`
-  font-size: 0.8rem;
+  font-size: 1em;
   text-decoration: line-through;
 `;
 
 interface ListingPriceProps {
   price: Money;
   oldPrice?: Money;
+  largerFont?: boolean;
 }
 
 /**
  * Listing price component that shows the current price and its previous price.
  */
-const ListingPrice: React.FC<ListingPriceProps> = ({price, oldPrice}) => (
+const ListingPrice: React.FC<ListingPriceProps> = ({price, oldPrice, largerFont}) => (
   <PriceContainer>
-    <Price>{formatMoney(price)}</Price>
+    <Price largerFont={largerFont}>{formatMoney(price)}</Price>
     {oldPrice && <OldPrice>{formatMoney(oldPrice)}</OldPrice>}
   </PriceContainer>
 );

--- a/web/src/components/customer/explore/ListingCollection.tsx
+++ b/web/src/components/customer/explore/ListingCollection.tsx
@@ -21,7 +21,7 @@ import CommitProgress from 'components/common/CommitProgress';
 import ListingCard from 'components/common/ListingCard';
 import StrippedCol from 'components/common/StrippedCol';
 import {Listing} from 'interfaces';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 
 interface ListingProps {
   listing: Listing;
@@ -40,12 +40,14 @@ const ListingItem: React.FC<ListingProps> = ({
   },
 }) => (
   <StrippedCol xs={6} key={id}>
-    <Link to={{
-      pathname: `/listing/${id}`,
-      state: {
-        fromExplore: true
-      }
-    }}>
+    <Link
+      to={{
+        pathname: `/listing/${id}`,
+        state: {
+          fromExplore: true,
+        },
+      }}
+    >
       <ListingCard
         listingName={name}
         price={price}

--- a/web/src/components/customer/explore/ListingCollection.tsx
+++ b/web/src/components/customer/explore/ListingCollection.tsx
@@ -21,6 +21,7 @@ import CommitProgress from 'components/common/CommitProgress';
 import ListingCard from 'components/common/ListingCard';
 import StrippedCol from 'components/common/StrippedCol';
 import {Listing} from 'interfaces';
+import { Link } from 'react-router-dom';
 
 interface ListingProps {
   listing: Listing;
@@ -39,19 +40,21 @@ const ListingItem: React.FC<ListingProps> = ({
   },
 }) => (
   <StrippedCol xs={6} key={id}>
-    <ListingCard
-      listingName={name}
-      price={price}
-      oldPrice={oldPrice}
-      endDate={deadline}
-      imgUrl={imgUrl}
-    >
-      <CommitProgress
-        numCommits={numCommits}
-        minCommits={minCommits}
-        textPos="none"
-      />
-    </ListingCard>
+    <Link to={`/listing/${id}`}>
+      <ListingCard
+        listingName={name}
+        price={price}
+        oldPrice={oldPrice}
+        endDate={deadline}
+        imgUrl={imgUrl}
+      >
+        <CommitProgress
+          numCommits={numCommits}
+          minCommits={minCommits}
+          textPos="none"
+        />
+      </ListingCard>
+    </Link>
   </StrippedCol>
 );
 

--- a/web/src/components/customer/explore/ListingCollection.tsx
+++ b/web/src/components/customer/explore/ListingCollection.tsx
@@ -40,7 +40,12 @@ const ListingItem: React.FC<ListingProps> = ({
   },
 }) => (
   <StrippedCol xs={6} key={id}>
-    <Link to={`/listing/${id}`}>
+    <Link to={{
+      pathname: `/listing/${id}`,
+      state: {
+        fromExplore: true
+      }
+    }}>
       <ListingCard
         listingName={name}
         price={price}

--- a/web/src/components/customer/listing-details/ListingDetails.tsx
+++ b/web/src/components/customer/listing-details/ListingDetails.tsx
@@ -39,17 +39,15 @@ interface ListingDetailsProps {
 /**
  * ListingDetailsSection that contains full listing details.
  */
-const ListingDetails: React.FC<ListingDetailsProps> = ({
-  listing,
-}) => {
+const ListingDetails: React.FC<ListingDetailsProps> = ({listing}) => {
   const {name, imgUrl} = listing;
 
   return (
     <>
       <ListingImage src={imgUrl} alt={`Image of ${name}`} />
-			<SectionContainer>
+      <SectionContainer>
         <ListingDescription listing={listing} />
-			</SectionContainer>
+      </SectionContainer>
     </>
   );
 };

--- a/web/src/components/customer/listing-details/ListingDetails.tsx
+++ b/web/src/components/customer/listing-details/ListingDetails.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import ListingDescription from 'components/common/ListingDescription';
+import {Listing} from 'interfaces';
+import {Container} from 'muicss/react';
+import styled from 'styled-components';
+
+const ListingImage = styled.img`
+  width: 100%;
+  height: 280px;
+  object-fit: cover;
+  background-color: var(--light-gray);
+`;
+
+const SectionContainer = styled(Container)`
+  padding: 0 1.8rem;
+`;
+
+interface ListingDetailsProps {
+  listing: Listing;
+}
+
+/**
+ * ListingDetailsSection that contains full listing details.
+ */
+const ListingDetails: React.FC<ListingDetailsProps> = ({
+  listing,
+}) => {
+  const {name, imgUrl} = listing;
+
+  return (
+    <>
+      <ListingImage src={imgUrl} alt={`Image of ${name}`} />
+			<SectionContainer>
+        <ListingDescription listing={listing} />
+			</SectionContainer>
+    </>
+  );
+};
+
+export default ListingDetails;

--- a/web/src/components/customer/listing-details/index.tsx
+++ b/web/src/components/customer/listing-details/index.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useState, useEffect} from 'react';
+
+import BackButton from 'components/common/BackButton';
+import {getListing} from 'api';
+import ListingDetails from 'components/customer/listing-details/ListingDetails';
+import {Listing} from 'interfaces';
+import {RouteComponentProps, Link} from 'react-router-dom';
+import styled from 'styled-components';
+import CommitsBadge from 'components/common/CommitsBadge';
+
+const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+interface ListingParams {
+  listingId?: string;
+}
+
+const ListingDetailsPage: React.FC<RouteComponentProps<ListingParams>> = ({
+  match: {
+    params: {listingId},
+  },
+}) => {
+  const [listing, setListing] = useState<Listing>();
+
+  useEffect(() => {
+    const fetchListings = async () => {
+      const listing = await getListing(Number(listingId));
+      setListing(listing);
+    };
+    fetchListings();
+  }, []);
+
+  return (
+    <PageContainer>
+      <Link to="/">
+        <BackButton pos="absolute" />
+      </Link>
+      <CommitsBadge pos="absolute" />
+      {listing && <ListingDetails listing={listing} />}
+    </PageContainer>
+  );
+};
+
+export default ListingDetailsPage;

--- a/web/src/components/customer/listing-details/index.tsx
+++ b/web/src/components/customer/listing-details/index.tsx
@@ -16,13 +16,13 @@
 
 import React, {useState, useEffect} from 'react';
 
-import BackButton from 'components/common/BackButton';
 import {getListing} from 'api';
+import BackButton from 'components/common/BackButton';
+import CommitsBadge from 'components/common/CommitsBadge';
 import ListingDetails from 'components/customer/listing-details/ListingDetails';
 import {Listing} from 'interfaces';
-import {Link, useHistory, useParams, useLocation} from 'react-router-dom';
+import {useHistory, useParams, useLocation} from 'react-router-dom';
 import styled from 'styled-components';
-import CommitsBadge from 'components/common/CommitsBadge';
 
 const PageContainer = styled.div`
   display: flex;
@@ -53,9 +53,7 @@ const ListingDetailsPage: React.FC = () => {
   }, [listingId]);
 
   const handleBack = () =>
-    location.state?.fromExplore
-      ? history.goBack()
-      : history.push('/');
+    location.state?.fromExplore ? history.goBack() : history.push('/');
 
   return (
     <PageContainer>

--- a/web/src/components/customer/listing-details/index.tsx
+++ b/web/src/components/customer/listing-details/index.tsx
@@ -20,7 +20,7 @@ import BackButton from 'components/common/BackButton';
 import {getListing} from 'api';
 import ListingDetails from 'components/customer/listing-details/ListingDetails';
 import {Listing} from 'interfaces';
-import {RouteComponentProps, Link} from 'react-router-dom';
+import {Link, useHistory, useParams, useLocation} from 'react-router-dom';
 import styled from 'styled-components';
 import CommitsBadge from 'components/common/CommitsBadge';
 
@@ -30,14 +30,18 @@ const PageContainer = styled.div`
 `;
 
 interface ListingParams {
-  listingId?: string;
+  listingId: string;
 }
 
-const ListingDetailsPage: React.FC<RouteComponentProps<ListingParams>> = ({
-  match: {
-    params: {listingId},
-  },
-}) => {
+interface ListingLocation {
+  fromExplore: boolean;
+}
+
+const ListingDetailsPage: React.FC = () => {
+  const history = useHistory();
+  const location = useLocation<ListingLocation>();
+  const {listingId} = useParams<ListingParams>();
+
   const [listing, setListing] = useState<Listing>();
 
   useEffect(() => {
@@ -46,13 +50,16 @@ const ListingDetailsPage: React.FC<RouteComponentProps<ListingParams>> = ({
       setListing(listing);
     };
     fetchListings();
-  }, []);
+  }, [listingId]);
+
+  const handleBack = () =>
+    location.state?.fromExplore
+      ? history.goBack()
+      : history.push('/');
 
   return (
     <PageContainer>
-      <Link to="/">
-        <BackButton pos="absolute" />
-      </Link>
+      <BackButton pos="absolute" onClick={handleBack} />
       <CommitsBadge pos="absolute" />
       {listing && <ListingDetails listing={listing} />}
     </PageContainer>

--- a/web/src/components/listing-details/index.tsx
+++ b/web/src/components/listing-details/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {lazy, Suspense} from 'react';
+import React, {Suspense} from 'react';
 
 import Loading from 'components/common/Loading';
 import CustomerListingDetailsPage from 'components/customer/listing-details';

--- a/web/src/components/listing-details/index.tsx
+++ b/web/src/components/listing-details/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {lazy, Suspense} from 'react';
+
+import Loading from 'components/common/Loading';
+import CustomerListingDetailsPage from 'components/customer/listing-details';
+import {Switch, Route} from 'react-router-dom';
+
+const ListingDetailsRoutes: React.FC = () => (
+  <Suspense fallback={<Loading />}>
+    <Switch>
+      <Route exact path="/" component={CustomerListingDetailsPage} />
+    </Switch>
+  </Suspense>
+);
+
+export default ListingDetailsRoutes;

--- a/web/src/components/listing-details/index.tsx
+++ b/web/src/components/listing-details/index.tsx
@@ -18,11 +18,11 @@ import React from 'react';
 
 import CustomerListingDetailsPage from 'components/customer/listing-details';
 
-const ListingDetailsRoutes: React.FC = () => (
+const CommonListingDetailsPage: React.FC = () => (
   // TODO: In this file, do a check for whether vistor is a merchant or not.
-  // If visitor is a merchant, redirect to merchant listing endpoint: /merchant/listing/:id
+  // If visitor is a merchant, show the merchant facing listing details page.
   // Else, show them the customer facing listing details page.
   <CustomerListingDetailsPage />
 );
 
-export default ListingDetailsRoutes;
+export default CommonListingDetailsPage;

--- a/web/src/components/listing-details/index.tsx
+++ b/web/src/components/listing-details/index.tsx
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-import React, {Suspense} from 'react';
+import React from 'react';
 
-import Loading from 'components/common/Loading';
 import CustomerListingDetailsPage from 'components/customer/listing-details';
-import {Switch, Route} from 'react-router-dom';
 
 const ListingDetailsRoutes: React.FC = () => (
-  <Suspense fallback={<Loading />}>
-    <Switch>
-      <Route exact path="/" component={CustomerListingDetailsPage} />
-    </Switch>
-  </Suspense>
+  // TODO: In this file, do a check for whether vistor is a merchant or not.
+  // If visitor is a merchant, redirect to merchant listing endpoint: /merchant/listing/:id
+  // Else, show them the customer facing listing details page.
+  <CustomerListingDetailsPage />
 );
 
 export default ListingDetailsRoutes;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -46,7 +46,7 @@ code {
 }
 
 a {
-  color: var(--green);
+  color: inherit;
 }
 
 a:hover {


### PR DESCRIPTION
Closes #16 
# Changes

- Added a listing details page that users are routed to when they click on a listing in the explore page or directly visit `/listing/:id`
- Wired up the back navigation in the listing details page when users click on the back button
  * If user came from the Explore page, they will go back in browser history
  * If user came from elsewhere (eg. from a shared link), clicking back will navigate them to the explore page
- `/listing/:id` first routes to `src/components/listing-details` before showing the contents of `src/components/customer/listing-details`.
  * I added this extra layer of abstraction because merchants would see slightly different content from customers, and we don't really want to bloat up the components by making it a shared page.
  * This shared page in `src/components/listing-details` should do a check for whether the visitor is a merchant or not, and redirect the user to the merchant page if the user is a merchant (Left as a TODO for now until merchant side page is up)

**Here is a screenshot of how it looks like:**
![image](https://user-images.githubusercontent.com/25261058/85974302-ba382300-ba07-11ea-83a6-54e809fbe70f.png)

