### PR TITLE
Setup datastore testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ install:
 matrix:
   include:
     - name: 'Backend'
+      addons:
+        apt:
+          sources:
+            - google-cloud-xenial
+          packages:
+            - google-cloud-sdk
+            - google-cloud-sdk-datastore-emulator
       before_install:
         - cd server
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+dist: xenial
+  apt:
+    packages:
+      - google-cloud-sdk
 language: node_js
 node_js: 10
 cache: yarn
@@ -8,6 +12,9 @@ matrix:
     - name: 'Backend'
       before_install:
         - cd server
+      before_script:
+        - gcloud beta emulators datastore start --no-store-on-disk &
+        - $(gcloud beta emulators datastore env-init
       script:
         - yarn lint
         - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
-  apt:
-    packages:
-      - google-cloud-sdk
+apt:
+  packages:
+    - google-cloud-sdk
 language: node_js
 node_js: 10
 cache: yarn
@@ -13,8 +13,7 @@ matrix:
       before_install:
         - cd server
       before_script:
-        - gcloud beta emulators datastore start --no-store-on-disk &
-        - $(gcloud beta emulators datastore env-init
+        - yarn test:emulator &
       script:
         - yarn lint
         - yarn test

--- a/server/README.md
+++ b/server/README.md
@@ -44,9 +44,17 @@ Automatically fixes formatting and linting problems (if possible) according to
 Runs all tests. We are using [Jest](https://jestjs.io/) as our test framework, alongside [supertest](https://github.com/visionmedia/supertest)
 to test API endpoints.
 
+Make sure that you already have the local datastore emulator running in another terminal.
+Refer to the section on `yarn test:emulator` on how to run the emulator.
+
 ### `yarn test:watch`
 
 Launches the test runner in the interactive watch mode.
+
+### `yarn test:emulator`
+
+Runs the gcloud datastore emulator. Ensure that you already have the datastore emulator installed on your machine.
+Refer to the section on "Running tests locally" on installation instructions.
 
 ### `yarn clean`
 
@@ -83,3 +91,74 @@ Each of these folders contain the following files:
 
 Each file in this folder contains a group of constants that are closely related.
 The file name specifies the constants inside it.
+
+## Running tests locally
+
+### Installing Google Cloud Datastore Emulator
+
+Our integration tests requires the Google Cloud Datastore Emulator to be running locally on your machine.
+[Google Cloud documentation](https://cloud.google.com/datastore/docs/tools/datastore-emulator) contains some instructions on how to set the emulator up.
+If that works for you, that's great!
+But if you run into problems during installation on the Chromebook, please follow this guide instead.
+
+When attempting to install the emulator, you might face this error:
+
+```
+E: Package 'openjdk-8-jdk' has no installation candidate
+```
+
+This is because the Chromebook is running debian 10 which uses the "stable" package list, which does not include `openjdk-8-jdk`.
+`openjsk-8-jdk` is only available in the older package list (stretch) and newer package list (sid).
+In this tutorial, we will download the stretch package manually and then install it via dpkg.
+
+Run this in your terminal to download `openjdk-8-jdk`:
+
+```
+sudo wget http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jre-headless_8u252-b09-1\~deb9u1_amd64.deb \
+http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jre_8u252-b09-1\~deb9u1_amd64.deb \
+http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jdk-headless_8u252-b09-1\~deb9u1_amd64.deb \
+http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jdk_8u252-b09-1\~deb9u1_amd64.deb
+sudo dpkg -i --force-all openjdk-8-jre-headless_8u252-b09-1~deb9u1_amd64.deb openjdk-8-jre_8u252-b09-1~deb9u1_amd64.deb openjdk-8-jdk-headless_8u252-b09-1~deb9u1_amd64.deb openjdk-8-jdk_8u252-b09-1~deb9u1_amd64.deb
+```
+
+To check that you have successfully installed `openjdk-8-jdk`, run:
+
+```
+update-alternatives --display java
+```
+Ensure that you see `/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java` as one of the options.
+
+Now run:
+
+```
+sudo update-alternatives --config java
+```
+
+And select the `/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java` option.
+
+Now you can finally install the datastore emulator using either
+
+```
+gcloud components install cloud-datastore-emulator
+```
+
+or
+
+```
+sudo apt-get install google-cloud-sdk-datastore-emulator
+```
+Congratulations, you can now start running your emulator to run integration tests locally!
+
+### Running tests with the Google Cloud Datastore Emulator
+
+We need the datastore emulator to be running in another terminal window on the same machine in order to run our tests. To do so, run:
+
+```
+yarn test:emulator
+```
+
+Now open up a new terminal and run:
+
+```
+yarn test
+```

--- a/server/package.json
+++ b/server/package.json
@@ -39,11 +39,14 @@
     "@google-cloud/datastore": "^6.0.0",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.6",
+    "@types/node-fetch": "^2.5.7",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "firebase-admin": "^8.12.1",
-    "guid-typescript": "^1.0.9"
+    "guid-typescript": "^1.0.9",
+    "node-fetch": "^2.6.0",
+    "portfinder": "^1.0.26"
   },
   "husky": {
     "hooks": {
@@ -52,6 +55,8 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "globalSetup": "<rootDir>/tests/datastore-setup.ts",
+    "globalTeardown": "<rootDir>/tests/datastore-teardown.ts",
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ],

--- a/server/package.json
+++ b/server/package.json
@@ -11,9 +11,9 @@
     "clean": "gts clean",
     "compile": "tsc",
     "prepare": "yarn run compile",
-    "pretest": "yarn run compile && $(gcloud beta emulators datastore env-init)",
+    "pretest": "yarn run compile",
     "posttest": "yarn run lint",
-    "test": "cross-env NODE_ENV=test DATASTORE_EMULATOR_PORT=8081 jest --forceExit",
+    "test": "$(gcloud beta emulators datastore env-init) && cross-env NODE_ENV=test DATASTORE_EMULATOR_PORT=8081 jest --forceExit",
     "test:watch": "yarn test --watch",
     "test:emulator": "gcloud beta emulators datastore start --no-store-on-disk --host-port=localhost:8081"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -2,20 +2,20 @@
   "name": "gpay-group-buy-server",
   "version": "1.0.0",
   "repository": "git@github.com:googleinterns/gpay-group-buy.git",
-  "author": "Karen Frilya Celine",
   "license": "Apache-2.0",
   "scripts": {
     "start": "node build/src/index.js",
     "start:dev": "nodemon -r dotenv-flow/config src/index.ts --node-env=development",
     "lint": "gts check",
     "fix": "gts fix",
-    "test": "cross-env NODE_ENV=test jest --forceExit",
-    "test:watch": "cross-env NODE_ENV=test jest --watch",
     "clean": "gts clean",
     "compile": "tsc",
     "prepare": "yarn run compile",
-    "pretest": "yarn run compile",
-    "posttest": "yarn run lint"
+    "pretest": "yarn run compile && $(gcloud beta emulators datastore env-init)",
+    "posttest": "yarn run lint",
+    "test": "cross-env NODE_ENV=test DATASTORE_EMULATOR_PORT=8081 jest --forceExit",
+    "test:watch": "yarn test --watch",
+    "test:emulator": "gcloud beta emulators datastore start --no-store-on-disk --host-port=localhost:8081"
   },
   "devDependencies": {
     "@types/jest": "^26.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "prepare": "yarn run compile",
     "pretest": "yarn run compile",
     "posttest": "yarn run lint",
-    "test": "$(gcloud beta emulators datastore env-init) && cross-env NODE_ENV=test DATASTORE_EMULATOR_PORT=8081 jest --forceExit",
+    "test": "$(gcloud beta emulators datastore env-init) && cross-env NODE_ENV=test jest --forceExit",
     "test:watch": "yarn test --watch",
     "test:emulator": "gcloud beta emulators datastore start --no-store-on-disk --host-port=localhost:8081"
   },

--- a/server/tests/datastore-setup.ts
+++ b/server/tests/datastore-setup.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Datastore} from '@google-cloud/datastore';
+import portfinder from 'portfinder';
+
+import {CUSTOMER_KIND} from '../src/constants/kinds';
+import customerFixtures from './fixtures/customers';
+
+const datastore = new Datastore();
+
+/**
+ * Checks if we are running the datastore emulator.
+ * We do so by checking if the emulator port is in use.
+ */
+const isDatastoreEmulator = async () => {
+  const res = await portfinder.getPortPromise({port: 8081});
+  return res !== 8081;
+};
+
+/**
+ * Intializes Datastore emulator by populating the datastore with fixtures.
+ * Prevents the adding of test entities if datastore emulator is not running.
+ */
+const initDatastoreEmulator = async () => {
+  if (process.env.NODE_ENV !== 'test') {
+    console.error('Datastore Emulator can only be initialized for tests.');
+    return;
+  }
+  if (!isDatastoreEmulator()) {
+    console.error(
+      'Make sure you are running the Datastore Emulator. Run: gcloud beta emulators datastore start --no-store-on-disk'
+    );
+    return;
+  }
+
+  console.log('\nSetting up Datastore Emulator...');
+
+  const customerEntities = customerFixtures.data.map((data, idx) => {
+    const id = customerFixtures.ids[idx];
+    const key = datastore.key([CUSTOMER_KIND, id]);
+    return {key, data};
+  });
+
+  await datastore.upsert(customerEntities);
+};
+
+export default initDatastoreEmulator;

--- a/server/tests/datastore-setup.ts
+++ b/server/tests/datastore-setup.ts
@@ -26,8 +26,7 @@ const datastore = new Datastore();
  * Checks if we are running the datastore emulator.
  * We do so by checking if the emulator port is in use.
  */
-const isDatastoreEmulator = async () => {
-  const port = Number(process.env.DATASTORE_EMULATOR_PORT);
+const isDatastoreEmulator = async (port: number) => {
   const res = await portfinder.getPortPromise({port});
   return res !== port;
 };
@@ -41,16 +40,24 @@ const initDatastoreEmulator = async () => {
     console.error('Datastore Emulator can only be initialized for tests.');
     return;
   }
-  const isEmulatorRunning = await isDatastoreEmulator();
+  if (process.env.DATASTORE_EMULATOR_HOST === undefined) {
+    console.error(
+      'Make sure you have initialized the Datastore Emulator env.\n' +
+        'Run: $(gcloud beta emulators datastore env-init)'
+    );
+    return;
+  }
+  const port = process.env.DATASTORE_EMULATOR_HOST.split(':').pop();
+  const isEmulatorRunning = await isDatastoreEmulator(Number(port));
   if (!isEmulatorRunning) {
     console.error(
-      'Make sure you are running the Datastore Emulator. Run: gcloud beta emulators datastore start --no-store-on-disk'
+      'Make sure you are running the Datastore Emulator.\n' +
+        'Run: gcloud beta emulators datastore start --no-store-on-disk'
     );
     return;
   }
 
   console.log('\nSetting up Datastore Emulator...');
-
   const customerEntities = customerFixtures.data.map((data, idx) => {
     const id = customerFixtures.ids[idx];
     const key = datastore.key([CUSTOMER_KIND, id]);

--- a/server/tests/datastore-setup.ts
+++ b/server/tests/datastore-setup.ts
@@ -41,7 +41,8 @@ const initDatastoreEmulator = async () => {
     console.error('Datastore Emulator can only be initialized for tests.');
     return;
   }
-  if (!isDatastoreEmulator()) {
+  const isEmulatorRunning = await isDatastoreEmulator();
+  if (!isEmulatorRunning) {
     console.error(
       'Make sure you are running the Datastore Emulator. Run: gcloud beta emulators datastore start --no-store-on-disk'
     );

--- a/server/tests/datastore-setup.ts
+++ b/server/tests/datastore-setup.ts
@@ -27,8 +27,9 @@ const datastore = new Datastore();
  * We do so by checking if the emulator port is in use.
  */
 const isDatastoreEmulator = async () => {
-  const res = await portfinder.getPortPromise({port: 8081});
-  return res !== 8081;
+  const port = Number(process.env.DATASTORE_EMULATOR_PORT);
+  const res = await portfinder.getPortPromise({port});
+  return res !== port;
 };
 
 /**
@@ -48,6 +49,7 @@ const initDatastoreEmulator = async () => {
   }
 
   console.log('\nSetting up Datastore Emulator...');
+  console.log(process.env.DATASTORE_EMULATOR_PORT);
 
   const customerEntities = customerFixtures.data.map((data, idx) => {
     const id = customerFixtures.ids[idx];

--- a/server/tests/datastore-setup.ts
+++ b/server/tests/datastore-setup.ts
@@ -49,7 +49,6 @@ const initDatastoreEmulator = async () => {
   }
 
   console.log('\nSetting up Datastore Emulator...');
-  console.log(process.env.DATASTORE_EMULATOR_PORT);
 
   const customerEntities = customerFixtures.data.map((data, idx) => {
     const id = customerFixtures.ids[idx];

--- a/server/tests/datastore-teardown.ts
+++ b/server/tests/datastore-teardown.ts
@@ -24,9 +24,11 @@ const teardownDatastoreEmulator = async () => {
     console.error('This function can only be run during tests.');
     return;
   }
+
   console.log('\nTearing down Datastore Emulator...');
+  console.log(process.env.DATASTORE_EMULATOR_PORT);
   // Make a post request to <emulator_host>:<emulator_port> to reset emulator data
-  await fetch('http://localhost:8081/reset', {
+  await fetch(`http://localhost:${process.env.DATASTORE_EMULATOR_PORT}/reset`, {
     method: 'post',
   });
 };

--- a/server/tests/datastore-teardown.ts
+++ b/server/tests/datastore-teardown.ts
@@ -26,9 +26,8 @@ const teardownDatastoreEmulator = async () => {
   }
 
   console.log('\nTearing down Datastore Emulator...');
-  console.log(process.env.DATASTORE_EMULATOR_PORT);
   // Make a post request to <emulator_host>:<emulator_port> to reset emulator data
-  await fetch(`http://localhost:${process.env.DATASTORE_EMULATOR_PORT}/reset`, {
+  await fetch(`http://${process.env.DATASTORE_EMULATOR_HOST}/reset`, {
     method: 'post',
   });
 };

--- a/server/tests/datastore-teardown.ts
+++ b/server/tests/datastore-teardown.ts
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-import request from 'supertest';
+import fetch from 'node-fetch';
 
-import app from '../../src';
-import customerFixtures from '../fixtures/customers';
-
-describe('Customers endpoints', () => {
-  test('it should fetch a single customer', async () => {
-    const expectedCustomerData = customerFixtures.data?.[0];
-    const customerId = customerFixtures.ids?.[0];
-    const res = await request(app).get(`/customers/${customerId}`);
-    expect(res.body).toMatchObject({
-      id: customerId,
-      ...expectedCustomerData,
-    });
+/**
+ * Teardown Datastore emulator by resetting the datastore emulator.
+ */
+const teardownDatastoreEmulator = async () => {
+  if (process.env.NODE_ENV !== 'test') {
+    console.error('This function can only be run during tests.');
+    return;
+  }
+  console.log('\nTearing down Datastore Emulator...');
+  // Make a post request to <emulator_host>:<emulator_port> to reset emulator data
+  await fetch('http://localhost:8081/reset', {
+    method: 'post',
   });
-});
+};
+
+export default teardownDatastoreEmulator;

--- a/server/tests/fixtures/customers.ts
+++ b/server/tests/fixtures/customers.ts
@@ -14,19 +14,30 @@
  * limitations under the License.
  */
 
-import request from 'supertest';
+/**
+ * Test data of customers.
+ */
+const data = [
+  {
+    address: 'Blk 42, Serangoon Road, #01-22',
+    contactNumber: '+6591234567',
+    gpayId: 1,
+  },
+  {
+    address: 'Blk 2, Ang Mo Kio Ave 10, #18-02',
+    contactNumber: '+6593320321',
+    gpayId: 2,
+  },
+  {
+    address: 'Blk 7, Pasir Ris St 72, #05-01',
+    contactNumber: '+6581045287',
+    gpayId: 3,
+  },
+];
 
-import app from '../../src';
-import customerFixtures from '../fixtures/customers';
+/**
+ * Test datastore ids for customers.
+ */
+const ids = data.map((_, idx) => idx + 1);
 
-describe('Customers endpoints', () => {
-  test('it should fetch a single customer', async () => {
-    const expectedCustomerData = customerFixtures.data?.[0];
-    const customerId = customerFixtures.ids?.[0];
-    const res = await request(app).get(`/customers/${customerId}`);
-    expect(res.body).toMatchObject({
-      id: customerId,
-      ...expectedCustomerData,
-    });
-  });
-});
+export default {data, ids};

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -23,7 +23,9 @@ describe('Customers endpoints', () => {
   test('it should fetch a single customer', async () => {
     const expectedCustomerData = customerFixtures.data?.[0];
     const customerId = customerFixtures.ids?.[0];
+
     const res = await request(app).get(`/customers/${customerId}`);
+
     expect(res.body).toMatchObject({
       id: customerId,
       ...expectedCustomerData,

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -881,6 +881,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "14.0.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
@@ -1237,6 +1245,13 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+
+async@^2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1664,7 +1679,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1867,7 +1882,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2712,6 +2727,15 @@ form-data@^2.3.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -5068,6 +5092,15 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+portfinder@^1.0.26:
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.26.tgz#475658d56ca30bed72ac7f1378ed350bd1b64e70"
+  integrity sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==
+  dependencies:
+    async "^2.6.2"
+    debug "^3.1.1"
+    mkdirp "^0.5.1"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Closes #86 
# Changes
- Added README on how to run the datastore emulator locally
- Added travis script to download gcloud sdk and datastore emulator for backend tests, and run the datastore emulator as a background task before starting the tests
- Added some customer test fixtures and a simple test to the get customers endpoint
- Added setup and teardown scripts to add test fixtures and reset the emulator datastore before and after all tests

You can view the test log here: https://travis-ci.org/github/googleinterns/gpay-group-buy/jobs/704369214#L302