### PR TITLE
Make POST /customers endpoint return existing customer if customer with gpayId already exists

### DIFF
--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -53,8 +53,10 @@ customerRouter.post(
     const customerData: CustomerPayload = req.body;
 
     try {
-      const existingCustomer = await customerService.getCustomerWithData(
-        customerData
+      // Customers are unique by their gpayId, so we will retrieve
+      // the customer using their gpay Id.
+      const existingCustomer = await customerService.getCustomerWithGpayId(
+        customerData.gpayId
       );
       if (existingCustomer !== null) {
         const resourceUrl = `${process.env.SERVER_URL}/customers/${existingCustomer.id}`;

--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -18,8 +18,6 @@
  * @fileoverview Handles routing of /customers endpoints.
  */
 
-import {readSync} from 'fs';
-
 import {Router, Request, Response, NextFunction} from 'express';
 import {CustomerPayload} from 'interfaces';
 
@@ -43,7 +41,11 @@ customerRouter.get(
 );
 
 /**
- * Create a customer if they do not already exist.
+ * Endpoint for the "logging in" of customers.
+ * If the customer exists, return the customer details in the
+ * response body with code 200.
+ * Else, add the customer and return the added customer details
+ * in the response body with code 201.
  */
 customerRouter.post(
   '/',
@@ -51,11 +53,21 @@ customerRouter.post(
     const customerData: CustomerPayload = req.body;
 
     try {
-      const customer = await customerService.addCustomer(customerData);
-      const resourceUrl = `${process.env.SERVER_URL}/customers/${customer.id}`;
+      const existingCustomer = await customerService.getCustomerWithData(
+        customerData
+      );
+      if (existingCustomer !== null) {
+        const resourceUrl = `${process.env.SERVER_URL}/customers/${existingCustomer.id}`;
+        res.setHeader('Content-Location', resourceUrl);
+        res.status(200).send(existingCustomer);
+        return;
+      }
+
+      const addedCustomer = await customerService.addCustomer(customerData);
+      const resourceUrl = `${process.env.SERVER_URL}/customers/${addedCustomer.id}`;
       res.setHeader('Content-Location', resourceUrl);
       res.location(resourceUrl);
-      res.status(201).send(customer);
+      res.status(201).send(addedCustomer);
       // TODO: Add error handling with the appropriate response codes.
     } catch (error) {
       return next(error);

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -25,11 +25,18 @@ export interface CustomerPayload {
 }
 
 /**
+ * CustomerDatastoreReponse Interface that contains the fields of the Response that
+ * server side receives from the Datastore.
+ */
+export interface CustomerDatastoreReponse extends Required<CustomerPayload> {
+  id: number;
+}
+
+/**
  * CustomerResponse Interface that contains the fields of the Response that
  * client side would receive.
  */
-export interface CustomerResponse extends Required<CustomerPayload> {
-  id: number;
+export interface CustomerResponse extends CustomerDatastoreReponse {
   numOngoingCommits: number;
 }
 

--- a/server/src/services/customers.ts
+++ b/server/src/services/customers.ts
@@ -25,7 +25,7 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> =>
  * Gets a customer by identifying them with their gpayId.
  * Returns a CustomerResponse object when such a customer exits.
  * Returns null otherwise.
- * @param data Data of the customer that we are trying to get
+ * @param gpayId The gpay id of the customer to retrieve
  */
 const getCustomerWithGpayId = async (
   gpayId: string

--- a/server/src/services/customers.ts
+++ b/server/src/services/customers.ts
@@ -22,17 +22,15 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> =>
   customerStorage.getCustomer(customerId);
 
 /**
- * Gets a customer by identifying them with their data.
+ * Gets a customer by identifying them with their gpayId.
  * Returns a CustomerResponse object when such a customer exits.
  * Returns null otherwise.
  * @param data Data of the customer that we are trying to get
  */
-const getCustomerWithData = async (
-  data: CustomerPayload
+const getCustomerWithGpayId = async (
+  gpayId: string
 ): Promise<CustomerResponse | null> =>
-  // Customers are unique by their gpayId, so we will retrieve
-  // the customer using their gpay Id from storage.
-  customerStorage.getCustomerWithGpayId(data.gpayId);
+  customerStorage.getCustomerWithGpayId(gpayId);
 
 /**
  * Creates a customer if the customer is not already registered, and returns customer information.
@@ -47,4 +45,4 @@ const addCustomer = async (
     ...customer,
   });
 
-export default {getCustomer, getCustomerWithData, addCustomer};
+export default {getCustomer, getCustomerWithGpayId, addCustomer};

--- a/server/src/services/customers.ts
+++ b/server/src/services/customers.ts
@@ -22,6 +22,19 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> =>
   customerStorage.getCustomer(customerId);
 
 /**
+ * Gets a customer by identifying them with their data.
+ * Returns a CustomerResponse object when such a customer exits.
+ * Returns null otherwise.
+ * @param data Data of the customer that we are trying to get
+ */
+const getCustomerWithData = async (
+  data: CustomerPayload
+): Promise<CustomerResponse | null> =>
+  // Customers are unique by their gpayId, so we will retrieve
+  // the customer using their gpay Id from storage.
+  customerStorage.getCustomerWithGpayId(data.gpayId);
+
+/**
  * Creates a customer if the customer is not already registered, and returns customer information.
  * Else, an error would be thrown.
  * @param customer Data of the customer to be added
@@ -34,4 +47,4 @@ const addCustomer = async (
     ...customer,
   });
 
-export default {getCustomer, addCustomer};
+export default {getCustomer, getCustomerWithData, addCustomer};


### PR DESCRIPTION
Part of #58 

# Changes
- The `POST /customers` endpoint now returns the data of an existing customer if another customer with the same gpayId already exists. So now this is the updated behavior of `POST /customers`:
  * If a customer with the same gpayId exists, response body will include the details of the customer in the response body (similar to a get request), with status code 200
  * If the customer does not exists, this customer will be added to the datastore, and the reponse body will include the details of this newly added customer, with status code 201.

**Justification for using the same endpoint:**
We do not separate the endpoint because on the client side, we have no idea if a customer with the same gpayId already exists or not in our own database. Since we are using the Spot identity API to "login" users, we do not have separated "sign in" or "sign up" buttons, and hence we can just combine them into 1 endpoint to avoid extra round trip time to run both requests.
This behavior is actually similar to how Google OAuth "login" works, where a new account is created for new users, and if the user exists, we "login" instead.

# Testing

Here I will be running the `POST /customers` request twice with the same gpayId field. Note difference in the status code returned.

**Making the POST request for a new customer:**
![Screenshot 2020-07-03 at 2 37 29 PM](https://user-images.githubusercontent.com/25261058/86441265-87ab6480-bd3e-11ea-9fda-25d345d916f2.png)

**Making the POST request for an existing customer:**
![Screenshot 2020-07-03 at 2 37 51 PM](https://user-images.githubusercontent.com/25261058/86441362-ac9fd780-bd3e-11ea-8245-198a146fc5e0.png)
