### PR TITLE
Create Get All Merchants API

### DIFF
--- a/server/src/api/merchants.ts
+++ b/server/src/api/merchants.ts
@@ -30,9 +30,10 @@ merchantRouter.get(
   '/',
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const filters = Object.keys(req.query).map((key) =>
-        ({property: key, value: req.query[key]})
-      );
+      const filters = Object.keys(req.query).map(key => ({
+        property: key,
+        value: req.query[key],
+      }));
       const merchants = await merchantService.getAllMerchants(filters);
       res.status(200).json(merchants);
     } catch (error) {

--- a/server/src/api/merchants.ts
+++ b/server/src/api/merchants.ts
@@ -26,6 +26,21 @@ import {merchantService} from '../services';
 
 const merchantRouter: Router = Router();
 
+merchantRouter.get(
+  '/',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const filters = Object.keys(req.query).map((key) =>
+        ({property: key, value: req.query[key]})
+      );
+      const merchants = await merchantService.getAllMerchants(filters);
+      res.status(200).json(merchants);
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
 merchantRouter.post(
   '/',
   merchantAuth,

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -126,3 +126,11 @@ export interface MerchantPayload {
 export interface MerchantResponse extends MerchantPayload {
   id: number;
 }
+
+/**
+ * Filter Interface that contains the fields of a filter query.
+ */
+export interface Filter {
+  property: string;
+  value: any;
+}

--- a/server/src/services/merchants.ts
+++ b/server/src/services/merchants.ts
@@ -23,7 +23,7 @@ const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
 const getAllMerchants = async (
   filters?: Filter[]
 ): Promise<MerchantResponse[]> => merchantStorage.getAllMerchants(filters);
-// TODO(#87): Restrict request such that the merchants themselves can get all the
+// TODO(#87): Add restriction such that the merchants themselves can get all the
 // fields but other merchants/customers can get only public fields like name.
 
 export default {addMerchant, getAllMerchants};

--- a/server/src/services/merchants.ts
+++ b/server/src/services/merchants.ts
@@ -20,9 +20,10 @@ import {merchantStorage} from '../storage';
 const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
   merchantStorage.addMerchant(merchant);
 
-const getAllMerchants = async (filters?: Filter[]): Promise<MerchantResponse[]> =>
-  merchantStorage.getAllMerchants(filters);
-  // TODO(#87): Restrict request such that the merchants themselves can get all the
-  // fields but other merchants/customers can get only public fields like name.
+const getAllMerchants = async (
+  filters?: Filter[]
+): Promise<MerchantResponse[]> => merchantStorage.getAllMerchants(filters);
+// TODO(#87): Restrict request such that the merchants themselves can get all the
+// fields but other merchants/customers can get only public fields like name.
 
 export default {addMerchant, getAllMerchants};

--- a/server/src/services/merchants.ts
+++ b/server/src/services/merchants.ts
@@ -25,5 +25,6 @@ const getAllMerchants = async (
 ): Promise<MerchantResponse[]> => merchantStorage.getAllMerchants(filters);
 // TODO(#87): Add restriction such that the merchants themselves can get all the
 // fields but other merchants/customers can get only public fields like name.
+// TODO(#102): Add checks to ensure that filters have valid properties
 
 export default {addMerchant, getAllMerchants};

--- a/server/src/services/merchants.ts
+++ b/server/src/services/merchants.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-import {MerchantPayload} from '../interfaces';
+import {Filter, MerchantPayload, MerchantResponse} from '../interfaces';
 import {merchantStorage} from '../storage';
 
 const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
   merchantStorage.addMerchant(merchant);
 
-export default {addMerchant};
+const getAllMerchants = async (filters?: Filter[]): Promise<MerchantResponse[]> =>
+  merchantStorage.getAllMerchants(filters);
+  // TODO(#87): Restrict request such that the merchants themselves can get all the
+  // fields but other merchants/customers can get only public fields like name.
+
+export default {addMerchant, getAllMerchants};

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -17,7 +17,7 @@
 import {Datastore} from '@google-cloud/datastore';
 import {Entity} from '@google-cloud/datastore/build/src/entity';
 
-import {Filter} from './interfaces';
+import {Filter} from '../interfaces';
 
 const datastore = new Datastore();
 

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -18,11 +18,3 @@
  * ResponseId type is the union type of datastore's built-in id.
  */
 export type ResponseId = number | Long | string | null;
-
-/**
- * Filter Interface that contains the fields of a filter query for datastore.
- */
-export interface Filter {
-  property: string;
-  value: any;
-}

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -20,11 +20,14 @@
  */
 
 import {MERCHANT_KIND} from '../constants/kinds';
-import {MerchantPayload} from '../interfaces';
-import {add} from './datastore';
+import {Filter, MerchantPayload, MerchantResponse} from '../interfaces';
+import {add, getAll} from './datastore';
 
 const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
   add(MERCHANT_KIND, merchant);
 // TODO(#67): Add checks to prevent adding multiple merchants with the same Firebase UID.
 
-export default {addMerchant};
+const getAllMerchants = async (filters?: Filter[]): Promise<MerchantResponse[]> =>
+  getAll(MERCHANT_KIND, filters);
+
+export default {addMerchant, getAllMerchants};

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -30,6 +30,5 @@ const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
 const getAllMerchants = async (
   filters?: Filter[]
 ): Promise<MerchantResponse[]> => getAll(MERCHANT_KIND, filters);
-// TODO(#102): Add checks to ensure that filters have valid properties
 
 export default {addMerchant, getAllMerchants};

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -27,7 +27,8 @@ const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
   add(MERCHANT_KIND, merchant);
 // TODO(#67): Add checks to prevent adding multiple merchants with the same Firebase UID.
 
-const getAllMerchants = async (filters?: Filter[]): Promise<MerchantResponse[]> =>
-  getAll(MERCHANT_KIND, filters);
+const getAllMerchants = async (
+  filters?: Filter[]
+): Promise<MerchantResponse[]> => getAll(MERCHANT_KIND, filters);
 
 export default {addMerchant, getAllMerchants};

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -30,5 +30,6 @@ const addMerchant = async (merchant: MerchantPayload): Promise<number> =>
 const getAllMerchants = async (
   filters?: Filter[]
 ): Promise<MerchantResponse[]> => getAll(MERCHANT_KIND, filters);
+// TODO(#102): Add checks to ensure that filters have valid properties
 
 export default {addMerchant, getAllMerchants};


### PR DESCRIPTION
Add get merchants API that allows filters using query parameters.

**To do in future PRs:**
- (#87) Restrict response so that only the merchants themselves can get all the fields but other merchants/customers can get only public fields like name.
  - Right now, everyone can get all merchant objects including all the fields (name, email, VPA) except for password.