### PR TITLE
Add microapps API

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -24,6 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <!-- Load gpay microapps APIs -->
+    <script async src="https://microapps.google.com/apis/v1alpha/microapps.js"></script>
     <title>GPay GroupBuy</title>
   </head>
   <body>

--- a/web/src/custom-typings/window/index.d.ts
+++ b/web/src/custom-typings/window/index.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  interface Window {
+    microapps: any;
+  }
+}
+
+// Export nothing.
+// Added because we can only `declare global` in files that has import or export.
+export {};

--- a/web/src/microapps.ts
+++ b/web/src/microapps.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Microapps API.
+ */
+const microapps = window.microapps;
+
+export default microapps;


### PR DESCRIPTION
Add microapps API to our app, we can now use the api by importing `import microapps from 'microapps';`

When we add microapps API through the script tag in `index.html`, we can access it via `window.microapps`. 
However, since we are using TypeScript, TypeScript will complain because microapps is not a known property of Window. A common workaround is to simply `declare const window: any`. However we would want to avoid that as we want to retain the typechecking of window's existing properties. So in this PR, I extended the Window interface in `web/src/custom-typings/window/index.d.ts` by adding a `microapps` property instead. 