### PR TITLE
Add customer signinsignup on client side

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -38,7 +38,6 @@ export const loginCustomer = async (
   customerData: CustomerPayload,
   idToken: string
 ): Promise<Customer> => {
-  const successfulStatusCodes = 200 | 201;
   const requestOptions = {
     method: 'POST',
     headers: {
@@ -52,7 +51,7 @@ export const loginCustomer = async (
     requestOptions
   );
 
-  if (res.status !== successfulStatusCodes) {
+  if (res.status !== 200 && res.status !== 201) {
     throw new Error(Errors.SERVER_ERROR);
   }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -30,9 +30,9 @@ export const getCustomer = async (customerId: number): Promise<Customer> => {
 };
 
 /**
- * Logs in a customer using their
- * @param customerData
- * @param idToken
+ * Logs in a customer or registers a new one if it is a new user.
+ * @param customerData Data of the customer to login/register
+ * @param idToken Authentication token of customer
  */
 export const loginCustomer = async (
   customerData: CustomerPayload,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -16,7 +16,7 @@
 
 import Errors from 'constants/sign-up-errors';
 
-import {Customer, Listing, MerchantPayload, MerchantResponse} from 'interfaces';
+import {Customer, Listing, CustomerPayload, MerchantPayload, MerchantResponse} from 'interfaces';
 
 /**
  * Fetches a particular customer with the specified customerId.
@@ -26,6 +26,36 @@ export const getCustomer = async (customerId: number): Promise<Customer> => {
   const res = await fetch(
     `${process.env.REACT_APP_SERVER_URL}/customers/${customerId}`
   );
+  return res.json();
+};
+
+/**
+ * Logs in a customer using their
+ * @param customerData
+ * @param idToken
+ */
+export const loginCustomer = async (
+  customerData: CustomerPayload,
+  idToken: string
+): Promise<Customer> => {
+  const successfulStatusCodes = 200 | 201;
+  const requestOptions = {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(customerData),
+  };
+  const res = await fetch(
+    `${process.env.REACT_APP_SERVER_URL}/customers`,
+    requestOptions
+  );
+
+  if (res.status !== successfulStatusCodes) {
+    throw new Error(Errors.SERVER_ERROR);
+  }
+
   return res.json();
 };
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -16,7 +16,13 @@
 
 import Errors from 'constants/sign-up-errors';
 
-import {Customer, Listing, CustomerPayload, MerchantPayload, MerchantResponse} from 'interfaces';
+import {
+  Customer,
+  Listing,
+  CustomerPayload,
+  MerchantPayload,
+  MerchantResponse,
+} from 'interfaces';
 
 /**
  * Fetches a particular customer with the specified customerId.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -51,10 +51,6 @@ export const loginCustomer = async (
     requestOptions
   );
 
-  if (res.status !== 200 && res.status !== 201) {
-    throw new Error(Errors.SERVER_ERROR);
-  }
-
   return res.json();
 };
 

--- a/web/src/components/common/CommitsBadge.tsx
+++ b/web/src/components/common/CommitsBadge.tsx
@@ -87,7 +87,9 @@ const CommitsBadge: React.FC<CommitsBadgeProps> = ({pos = 'static'}) => {
       <>
         Commits Left:
         <CommitCount>
-          {numCommits !== undefined && <>{Math.max(MAX_NUM_COMMITS - numCommits, 0)}</>}
+          {numCommits !== undefined && (
+            <>{Math.max(MAX_NUM_COMMITS - numCommits, 0)}</>
+          )}
         </CommitCount>
         out of {MAX_NUM_COMMITS}
       </>

--- a/web/src/components/common/CommitsBadge.tsx
+++ b/web/src/components/common/CommitsBadge.tsx
@@ -87,7 +87,7 @@ const CommitsBadge: React.FC<CommitsBadgeProps> = ({pos = 'static'}) => {
       <>
         Commits Left:
         <CommitCount>
-          {numCommits && <>{Math.max(MAX_NUM_COMMITS - numCommits, 0)}</>}
+          {numCommits !== undefined && <>{Math.max(MAX_NUM_COMMITS - numCommits, 0)}</>}
         </CommitCount>
         out of {MAX_NUM_COMMITS}
       </>

--- a/web/src/components/customer/explore/index.tsx
+++ b/web/src/components/customer/explore/index.tsx
@@ -16,10 +16,11 @@
 
 import React from 'react';
 
-import {getCustomer} from 'api';
+import {getCustomer, loginCustomer} from 'api';
 import CommitsBadge from 'components/common/CommitsBadge';
 import {useCommitCountContext} from 'components/customer/contexts/CommitCountContext';
 import ListingCollection from 'components/customer/explore/ListingCollection';
+import {getIdentity} from 'microapps';
 import Button from 'muicss/lib/react/button';
 import Container from 'muicss/lib/react/container';
 import styled from 'styled-components';
@@ -46,6 +47,15 @@ const CustomerExplorePage: React.FC = () => {
     setNumCommits(numOngoingCommits);
   };
 
+  const handleGetIdentity = async () => {
+    const {idToken, decodedToken: {sub}} = await getIdentity();
+    const {numOngoingCommits} = await loginCustomer(
+      {gpayId: sub},
+      idToken
+    );
+    setNumCommits(numOngoingCommits);
+  };
+
   return (
     <PageContainer>
       <CommitsBadgeContainer>
@@ -55,6 +65,9 @@ const CustomerExplorePage: React.FC = () => {
       <ListingCollection />
       <Button color="primary" onClick={handleGetSampleCustomer}>
         Click for commit info of sample customer
+      </Button>
+      <Button color="primary" onClick={handleGetIdentity}>
+        Get Identity
       </Button>
     </PageContainer>
   );

--- a/web/src/components/customer/explore/index.tsx
+++ b/web/src/components/customer/explore/index.tsx
@@ -48,11 +48,11 @@ const CustomerExplorePage: React.FC = () => {
   };
 
   const handleGetIdentity = async () => {
-    const {idToken, decodedToken: {sub}} = await getIdentity();
-    const {numOngoingCommits} = await loginCustomer(
-      {gpayId: sub},
-      idToken
-    );
+    const {
+      idToken,
+      decodedToken: {sub},
+    } = await getIdentity();
+    const {numOngoingCommits} = await loginCustomer({gpayId: sub}, idToken);
     setNumCommits(numOngoingCommits);
   };
 

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -57,11 +57,21 @@ export interface Listing {
   listingStatus: ListingStatus;
 }
 
-export interface Customer {
-  id: number;
+/**
+ * CustomerPayload Interface that contains the fields of the payload that
+ * would be sent to the server.
+ */
+export interface CustomerPayload {
   gpayId: string; // E164 format
-  contactNumber: string;
-  address: string;
+  contactNumber?: string;
+  address?: string;
+}
+
+/**
+ * Customer Interface that contains the fields of a Customer.
+ */
+export interface Customer extends Required<CustomerPayload> {
+  id: number;
   numOngoingCommits: number;
 }
 

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -62,8 +62,8 @@ export interface Listing {
  * would be sent to the server.
  */
 export interface CustomerPayload {
-  gpayId: string; // E164 format
-  contactNumber?: string;
+  gpayId: string;
+  contactNumber?: string; // E164 format
   address?: string;
 }
 

--- a/web/src/microapps.ts
+++ b/web/src/microapps.ts
@@ -19,4 +19,21 @@
  */
 const microapps = window.microapps;
 
+/**
+ * Decodes a base64 microapps identity token.
+ * Method taken from https://developers.google.com/pay/spot/eap/reference/identity-api#full_example.
+ * @param idToken The token to be decoded
+ */
+export const decodeToken = (idToken: string) =>
+  JSON.parse(atob(idToken.split('.')[1]));
+
+/**
+ * Gets microapps identity token and its decoded form.
+ */
+export const getIdentity = async () => {
+  const idToken = await microapps.getIdentity();
+  const decodedToken = decodeToken(idToken);
+  return {idToken, decodedToken};
+};
+
 export default microapps;


### PR DESCRIPTION
Closes #58 
To be merged after #88 and #96 

# Changes
- Customers can now login via the microapps identity API
- After calling the identity API, call our sever login endpoint to signin/signup the customer and get the customer details
- Added a temporary "Get Identity" button to trigger this login process
- Clicking that button will update the numCommits in the NumCommitsContext

# How to test
Visit the app via GPay Spot app. 
Click on the "Get Identity" button. Permissions dialog should be triggered and you should see the Commits badge appear.

Sample network request & response from inspect:
![image](https://user-images.githubusercontent.com/25261058/86589720-c2243400-bfc0-11ea-93ad-12c5c671c400.png)
