### PR TITLE
Create get all commits endpoint

### DIFF
--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -36,7 +36,9 @@ commitRouter.get(
         res.sendStatus(400);
         return;
       }
-
+      // TODO: Parse queryParams json to make it CommitPayload type in runtime, which
+      // throws the appropriate type errors.
+      // Right now services is handling the type casting and throwing of errors.
       const commits = await commitService.getAllCommits(queryParams);
       res.status(200).json(commits);
       // TODO: Add error handling with the appropriate response codes.

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -24,6 +24,9 @@ import {commitService} from '../services';
 
 const commitRouter = express.Router();
 
+/**
+ * Handles the get request for retrieving all commits.
+ */
 commitRouter.get(
   '/',
   async (req: Request, res: Response, next: NextFunction) => {

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -30,6 +30,7 @@ commitRouter.get(
     try {
       const commits = await commitService.getAllCommits(req.query);
       res.status(200).json(commits);
+      // TODO: Add error handling with the appropriate response codes.
     } catch (error) {
       return next(error);
     }

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -16,10 +16,24 @@
 
 /**
  * @fileoverview Handles routing of /commits endpoints.
- * @author Karen Frilya Celine
  */
 
-import express from 'express';
-const router: express.Router = express.Router();
+import express, {Request, Response, NextFunction} from 'express';
 
-export const commitRouter: express.Router = router;
+import {commitService} from '../services';
+
+const commitRouter = express.Router();
+
+commitRouter.get(
+  '/',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const commits = await commitService.getAllCommits(req.query);
+      res.status(200).json(commits);
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+export default commitRouter;

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -31,7 +31,13 @@ commitRouter.get(
   '/',
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const commits = await commitService.getAllCommits(req.query);
+      const queryParams = req.query;
+      if (Object.keys(queryParams).length === 0) {
+        res.sendStatus(400);
+        return;
+      }
+
+      const commits = await commitService.getAllCommits(queryParams);
       res.status(200).json(commits);
       // TODO: Add error handling with the appropriate response codes.
     } catch (error) {

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -16,10 +16,9 @@
 
 /**
  * @fileoverview Handles routing of the different API routes.
- * @author Karen Frilya Celine
  */
 
-import {commitRouter} from './commits';
+import commitRouter from './commits';
 import customerRouter from './customers';
 import listingRouter from './listings';
 import merchantRouter from './merchants';

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -80,9 +80,13 @@ app.use(
 
 const localPort = process.env.NODE_ENV === 'test' ? 5001 : 5000;
 const port = process.env.PORT || localPort;
+
+// module.parent check to prevents the EADDRINUSE error for tests, following:
+// http://www.marcusoft.net/2015/10/eaddrinuse-when-watching-tests-with-mocha-and-supertest.html
 if (!module.parent) {
   app.listen(port, () => console.log(`Listening on port ${port}`));
 }
+
 const onStopSignal = () => {
   console.log('Termination signal received, exiting process..');
   process.exit(1); // eslint-disable-line no-process-exit

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -80,8 +80,9 @@ app.use(
 
 const localPort = process.env.NODE_ENV === 'test' ? 5001 : 5000;
 const port = process.env.PORT || localPort;
-const server = app.listen(port, () => console.log(`Listening on port ${port}`));
-
+if (!module.parent) {
+  app.listen(port, () => console.log(`Listening on port ${port}`));
+}
 const onStopSignal = () => {
   console.log('Termination signal received, exiting process..');
   process.exit(1); // eslint-disable-line no-process-exit
@@ -93,4 +94,3 @@ process.on('SIGHUP', onStopSignal);
 process.on('SIGUSR2', onStopSignal); // Nodemon uses this
 
 export default app;
-export {server};

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -62,6 +62,11 @@ export interface CommitPayload {
 }
 
 /**
+ * Union type of the keys of CommitPayload.
+ */
+export type CommitPayloadKey = keyof CommitPayload;
+
+/**
  * CommitResponse Interface that contains the fields of the Response that
  * client side would receive.
  */
@@ -140,4 +145,11 @@ export interface MerchantResponse extends MerchantPayload {
 export interface Filter {
   property: string;
   value: any;
+}
+
+/**
+ * QueryParams Interface that contains the fields of parameters in a query.
+ */
+export interface QueryParams {
+  [x: string]: any;
 }

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -148,8 +148,8 @@ export interface Filter {
 }
 
 /**
- * QueryParams Interface that contains the fields of parameters in a query.
+ * A generic string key object.
  */
-export interface QueryParams {
-  [x: string]: any;
+export interface StringKeyObject {
+  [key: string]: any;
 }

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -31,7 +31,10 @@ import {commitStorage} from '../storage';
 const getAllCommits = async (
   queryParams: StringKeyObject
 ): Promise<CommitResponse[]> => {
-  const allowedKeys: Set<CommitPayloadKey> = new Set(['customerId', 'listingId']);
+  const allowedKeys: Set<CommitPayloadKey> = new Set([
+    'customerId',
+    'listingId',
+  ]);
   const filters: Filter[] = [];
   Object.keys(queryParams).forEach(key => {
     if (!(allowedKeys as Set<string>).has(key)) {

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -17,7 +17,7 @@
 import {
   Filter,
   CommitResponse,
-  QueryParams,
+  StringKeyObject,
   CommitPayloadKey,
 } from '../interfaces';
 import {commitStorage} from '../storage';
@@ -29,16 +29,12 @@ import {commitStorage} from '../storage';
  * @param queryParams The query parameters
  */
 const getAllCommits = async (
-  queryParams?: QueryParams
+  queryParams: StringKeyObject
 ): Promise<CommitResponse[]> => {
-  if (queryParams === undefined) {
-    return commitStorage.getAllCommits();
-  }
-
-  const allowedKeys: CommitPayloadKey[] = ['customerId', 'listingId'];
+  const allowedKeys: Set<CommitPayloadKey> = new Set(['customerId', 'listingId']);
   const filters: Filter[] = [];
   Object.keys(queryParams).forEach(key => {
-    if (!(allowedKeys as string[]).includes(key)) {
+    if (!(allowedKeys as Set<string>).has(key)) {
       throw new Error(`${key} is not a valid query parameter.`);
     }
 

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -14,6 +14,51 @@
  * limitations under the License.
  */
 
+import {
+  Filter,
+  CommitResponse,
+  QueryParams,
+  CommitPayloadKey,
+} from '../interfaces';
 import {commitStorage} from '../storage';
 
-export const commitService = {};
+/**
+ * Retrieves all commits.
+ * If query paramaters are provided, will retrieve all commits satisfying
+ * the query parameters.
+ * @param queryParams The query parameters
+ */
+const getAllCommits = async (
+  queryParams?: QueryParams
+): Promise<CommitResponse[]> => {
+  if (queryParams === undefined) {
+    return commitStorage.getAllCommits();
+  }
+
+  const allowedKeys: CommitPayloadKey[] = ['customerId', 'listingId'];
+  const filters: Filter[] = [];
+  Object.keys(queryParams).forEach(key => {
+    if (!(allowedKeys as string[]).includes(key)) {
+      throw new Error(`${key} is not a valid query parameter.`);
+    }
+
+    let value = queryParams[key];
+    switch (key) {
+      case 'customerId':
+      case 'listingId':
+        value = Number(value);
+        if (Number.isNaN(value)) {
+          throw new Error(`Invalid filter value provided for ${key}.`);
+        }
+        break;
+    }
+
+    filters.push({
+      property: key,
+      value,
+    });
+  });
+  return commitStorage.getAllCommits(filters);
+};
+
+export default {getAllCommits};

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -42,6 +42,7 @@ const getAllCommits = async (
     }
 
     let value = queryParams[key];
+    // TODO: Remove this check after we do the parsing in the api layer.
     switch (key) {
       case 'customerId':
       case 'listingId':

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {commitService} from './commits';
+import commitService from './commits';
 import customerService from './customers';
 import listingService from './listings';
 import merchantService from './merchants';

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -18,6 +18,10 @@ import {COMMIT_KIND} from '../constants/kinds';
 import {Filter, CommitResponse} from '../interfaces';
 import {getAll} from './datastore';
 
+/**
+ * Retrieves all commits satisfying the filters, if provided.
+ * @param filters Filters on the get query
+ */
 const getAllCommits = async (filters?: Filter[]): Promise<CommitResponse[]> =>
   getAll(COMMIT_KIND, filters);
 

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import {Datastore} from '@google-cloud/datastore';
-import {Guid} from 'guid-typescript';
+import {COMMIT_KIND} from '../constants/kinds';
+import {Filter, CommitResponse} from '../interfaces';
+import {getAll} from './datastore';
 
-const datastore = new Datastore();
+const getAllCommits = async (filters?: Filter[]): Promise<CommitResponse[]> =>
+  getAll(COMMIT_KIND, filters);
 
-export const commitStorage = {};
+export default {getAllCommits};

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {commitStorage} from './commits';
+import commitStorage from './commits';
 import customerStorage from './customers';
 import listingStorage from './listings';
 import merchantStorage from './merchants';

--- a/server/tests/datastore-setup.ts
+++ b/server/tests/datastore-setup.ts
@@ -17,8 +17,10 @@
 import {Datastore} from '@google-cloud/datastore';
 import portfinder from 'portfinder';
 
-import {CUSTOMER_KIND} from '../src/constants/kinds';
+import {CUSTOMER_KIND, COMMIT_KIND, LISTING_KIND} from '../src/constants/kinds';
+import commitFixtures from './fixtures/commits';
 import customerFixtures from './fixtures/customers';
+import listingFixtures from './fixtures/listings';
 
 const datastore = new Datastore();
 
@@ -63,8 +65,22 @@ const initDatastoreEmulator = async () => {
     const key = datastore.key([CUSTOMER_KIND, id]);
     return {key, data};
   });
+  const listingEntities = listingFixtures.data.map((data, idx) => {
+    const id = listingFixtures.ids[idx];
+    const key = datastore.key([LISTING_KIND, id]);
+    return {key, data};
+  });
+  const commitEntities = commitFixtures.data.map((data, idx) => {
+    const id = commitFixtures.ids[idx];
+    const key = datastore.key([COMMIT_KIND, id]);
+    return {key, data};
+  });
 
-  await datastore.upsert(customerEntities);
+  await datastore.upsert([
+    ...customerEntities,
+    ...listingEntities,
+    ...commitEntities,
+  ]);
 };
 
 export default initDatastoreEmulator;

--- a/server/tests/fixtures/commits.ts
+++ b/server/tests/fixtures/commits.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import customerFixtures from './customers';
+import listingFixtures from './listings';
+
+/**
+ * Test data of commits.
+ */
+const data = [
+  {
+    createdAt: new Date('2020-06-23T03:34:00.000Z'),
+    listingId: listingFixtures.ids[0],
+    customerId: customerFixtures.ids[0],
+    commitStatus: 'ongoing',
+  },
+  {
+    createdAt: new Date('2020-06-29T03:34:00.000Z'),
+    listingId: listingFixtures.ids[0],
+    customerId: customerFixtures.ids[1],
+    commitStatus: 'ongoing',
+  },
+];
+
+/**
+ * Test datastore ids for commits.
+ */
+const ids = data.map((_, idx) => idx + 1);
+
+const responseData = data.map((commit, idx) => ({
+  ...commit,
+  id: ids[idx],
+  createdAt: commit.createdAt.toISOString(),
+}));
+
+export default {data, ids, responseData};

--- a/server/tests/fixtures/commits.ts
+++ b/server/tests/fixtures/commits.ts
@@ -40,6 +40,9 @@ const data = [
  */
 const ids = data.map((_, idx) => idx + 1);
 
+/**
+ * Test response data for commits.
+ */
 const responseData = data.map((commit, idx) => ({
   ...commit,
   id: ids[idx],

--- a/server/tests/fixtures/customers.ts
+++ b/server/tests/fixtures/customers.ts
@@ -40,4 +40,12 @@ const data = [
  */
 const ids = data.map((_, idx) => idx + 1);
 
-export default {data, ids};
+/**
+ * Test response data for customers.
+ */
+const responseData = data.map((customer, idx) => ({
+  ...customer,
+  id: ids[idx],
+}));
+
+export default {data, ids, responseData};

--- a/server/tests/fixtures/listings.ts
+++ b/server/tests/fixtures/listings.ts
@@ -71,4 +71,13 @@ const data = [
  */
 const ids = data.map((_, idx) => idx + 1);
 
-export default {data, ids};
+/**
+ * Test response data for listings.
+ */
+const responseData = data.map((listing, idx) => ({
+  ...listing,
+  id: ids[idx],
+  deadline: listing.deadline.toISOString(),
+}));
+
+export default {data, ids, responseData};

--- a/server/tests/fixtures/listings.ts
+++ b/server/tests/fixtures/listings.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test data of listings.
+ */
+const data = [
+  {
+    name: 'Airpods',
+    description: 'Cheap airpods description.',
+    listingStatus: 'ongoing',
+    merchantId: 5644004762845184,
+    imgUrl:
+      'https://images.unsplash.com/photo-1512221472476-7e439affc029?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80',
+    price: {
+      currency: 'SGD',
+      dollars: 85,
+      cents: 0,
+    },
+    oldPrice: {
+      currency: 'SGD',
+      dollars: 100,
+      cents: 0,
+    },
+    numPaid: 0,
+    numCompleted: 0,
+    minCommits: 100,
+    deadline: new Date('2020-07-08T15:59:00.000Z'),
+    numCommits: 1,
+  },
+  {
+    name: 'Beats Solo',
+    description: 'Beautiful Beats description.',
+    listingStatus: 'ongoing',
+    merchantId: 5644004762845184,
+    imgUrl:
+      'https://images.unsplash.com/photo-1512221472476-7e439affc029?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80',
+    price: {
+      currency: 'SGD',
+      dollars: 299,
+      cents: 0,
+    },
+    oldPrice: {
+      currency: 'SGD',
+      dollars: 150,
+      cents: 0,
+    },
+    numPaid: 0,
+    numCompleted: 0,
+    minCommits: 100,
+    deadline: new Date('2020-07-09T15:59:00.000Z'),
+    numCommits: 0,
+  },
+];
+
+/**
+ * Test datastore ids for listings.
+ */
+const ids = data.map((_, idx) => idx + 1);
+
+export default {data, ids};

--- a/server/tests/integration/commits.test.ts
+++ b/server/tests/integration/commits.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import request from 'supertest';
+
+import app from '../../src';
+import commitFixtures from '../fixtures/commits';
+import customerFixtures from '../fixtures/customers';
+import listingFixtures from '../fixtures/listings';
+
+describe('Customers endpoints', () => {
+  describe('GET /commits', () => {
+    test('it should fetch all commits', async () => {
+      const expectedResponse = commitFixtures.responseData;
+
+      const res = await request(app).get('/commits');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expectedResponse);
+    });
+
+    test('it should filter by listingId query param', async () => {
+      const targetListingId = listingFixtures.ids?.[0];
+      const expectedResponse = commitFixtures.responseData.filter(
+        data => data.listingId === targetListingId
+      );
+
+      const res = await request(app).get('/commits').query({
+        listingId: targetListingId,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expectedResponse);
+    });
+
+    test('it should filter by customerId query param', async () => {
+      const targetCustomerId = customerFixtures.ids?.[0];
+      const expectedResponse = commitFixtures.responseData.filter(
+        data => data.customerId === targetCustomerId
+      );
+
+      const res = await request(app).get('/commits').query({
+        customerId: targetCustomerId,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expectedResponse);
+    });
+
+    test('it should filter by more than 1 query param', async () => {
+      const targetCustomerId = customerFixtures.ids?.[0];
+      const targetListingId = listingFixtures.ids?.[0];
+      const expectedResponse = commitFixtures.responseData.filter(
+        data =>
+          data.customerId === targetCustomerId &&
+          data.listingId === targetListingId
+      );
+
+      const res = await request(app).get('/commits').query({
+        customerId: targetCustomerId,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expectedResponse);
+    });
+
+    test('it should not filter by disallowed query params', async () => {
+      const res = await request(app).get('/commits').query({
+        createdAt: '2020-06-29T03:34:00.000Z',
+      });
+
+      expect(res.status).not.toBe(200);
+      expect(res.body).toHaveProperty('error');
+    });
+
+    test('it should not filter by invalid query values', async () => {
+      const res = await request(app).get('/commits').query({
+        customerId: 'invalid-customer-id-type',
+      });
+
+      expect(res.status).not.toBe(200);
+      expect(res.body).toHaveProperty('error');
+    });
+  });
+});

--- a/server/tests/integration/commits.test.ts
+++ b/server/tests/integration/commits.test.ts
@@ -24,17 +24,17 @@ import listingFixtures from '../fixtures/listings';
 describe('Customers endpoints', () => {
   describe('GET /commits', () => {
     test('it should fetch all commits', async () => {
-      const expectedResponse = commitFixtures.responseData;
+      const expectedCommitData = commitFixtures.responseData;
 
       const res = await request(app).get('/commits');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(expectedResponse);
+      expect(res.body).toEqual(expectedCommitData);
     });
 
     test('it should filter by listingId query param', async () => {
       const targetListingId = listingFixtures.ids?.[0];
-      const expectedResponse = commitFixtures.responseData.filter(
+      const expectedCommitData = commitFixtures.responseData.filter(
         data => data.listingId === targetListingId
       );
 
@@ -43,12 +43,12 @@ describe('Customers endpoints', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(expectedResponse);
+      expect(res.body).toEqual(expectedCommitData);
     });
 
     test('it should filter by customerId query param', async () => {
       const targetCustomerId = customerFixtures.ids?.[0];
-      const expectedResponse = commitFixtures.responseData.filter(
+      const expectedCommitData = commitFixtures.responseData.filter(
         data => data.customerId === targetCustomerId
       );
 
@@ -57,13 +57,13 @@ describe('Customers endpoints', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(expectedResponse);
+      expect(res.body).toEqual(expectedCommitData);
     });
 
     test('it should filter by more than 1 query param', async () => {
       const targetCustomerId = customerFixtures.ids?.[0];
       const targetListingId = listingFixtures.ids?.[0];
-      const expectedResponse = commitFixtures.responseData.filter(
+      const expectedCommitData = commitFixtures.responseData.filter(
         data =>
           data.customerId === targetCustomerId &&
           data.listingId === targetListingId
@@ -74,7 +74,7 @@ describe('Customers endpoints', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(expectedResponse);
+      expect(res.body).toEqual(expectedCommitData);
     });
 
     test('it should not filter by disallowed query params', async () => {

--- a/server/tests/integration/commits.test.ts
+++ b/server/tests/integration/commits.test.ts
@@ -80,8 +80,12 @@ describe('Commits endpoints', () => {
         createdAt: '2020-06-29T03:34:00.000Z',
       });
 
+      // TODO: Test for actual error status codes when implemented
       expect(res.status).not.toBe(200);
       expect(res.body).toHaveProperty('error');
+      expect(res.body.error.message).toBe(
+        'createdAt is not a valid query parameter.'
+      );
     });
 
     test('Should not filter by invalid query values', async () => {
@@ -89,8 +93,12 @@ describe('Commits endpoints', () => {
         customerId: 'invalid-customer-id-type',
       });
 
+      // TODO: Test for actual error status codes when implemented
       expect(res.status).not.toBe(200);
       expect(res.body).toHaveProperty('error');
+      expect(res.body.error.message).toBe(
+        'Invalid filter value provided for customerId.'
+      );
     });
   });
 });

--- a/server/tests/integration/commits.test.ts
+++ b/server/tests/integration/commits.test.ts
@@ -23,13 +23,10 @@ import listingFixtures from '../fixtures/listings';
 
 describe('Commits endpoints', () => {
   describe('GET /commits', () => {
-    test('it should fetch all commits', async () => {
-      const expectedCommitData = commitFixtures.responseData;
-
+    test('it should not be able to fetch all commits', async () => {
       const res = await request(app).get('/commits');
 
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual(expectedCommitData);
+      expect(res.status).toBe(400);
     });
 
     test('it should filter by listingId query param', async () => {

--- a/server/tests/integration/commits.test.ts
+++ b/server/tests/integration/commits.test.ts
@@ -21,7 +21,7 @@ import commitFixtures from '../fixtures/commits';
 import customerFixtures from '../fixtures/customers';
 import listingFixtures from '../fixtures/listings';
 
-describe('Customers endpoints', () => {
+describe('Commits endpoints', () => {
   describe('GET /commits', () => {
     test('it should fetch all commits', async () => {
       const expectedCommitData = commitFixtures.responseData;

--- a/server/tests/integration/commits.test.ts
+++ b/server/tests/integration/commits.test.ts
@@ -23,13 +23,13 @@ import listingFixtures from '../fixtures/listings';
 
 describe('Commits endpoints', () => {
   describe('GET /commits', () => {
-    test('it should not be able to fetch all commits', async () => {
+    test('Should not be able to fetch all commits', async () => {
       const res = await request(app).get('/commits');
 
       expect(res.status).toBe(400);
     });
 
-    test('it should filter by listingId query param', async () => {
+    test('Should filter by listingId query param', async () => {
       const targetListingId = listingFixtures.ids?.[0];
       const expectedCommitData = commitFixtures.responseData.filter(
         data => data.listingId === targetListingId
@@ -43,7 +43,7 @@ describe('Commits endpoints', () => {
       expect(res.body).toEqual(expectedCommitData);
     });
 
-    test('it should filter by customerId query param', async () => {
+    test('Should filter by customerId query param', async () => {
       const targetCustomerId = customerFixtures.ids?.[0];
       const expectedCommitData = commitFixtures.responseData.filter(
         data => data.customerId === targetCustomerId
@@ -57,7 +57,7 @@ describe('Commits endpoints', () => {
       expect(res.body).toEqual(expectedCommitData);
     });
 
-    test('it should filter by more than 1 query param', async () => {
+    test('Should filter by more than 1 query param', async () => {
       const targetCustomerId = customerFixtures.ids?.[0];
       const targetListingId = listingFixtures.ids?.[0];
       const expectedCommitData = commitFixtures.responseData.filter(
@@ -68,13 +68,14 @@ describe('Commits endpoints', () => {
 
       const res = await request(app).get('/commits').query({
         customerId: targetCustomerId,
+        listingId: targetListingId,
       });
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(expectedCommitData);
     });
 
-    test('it should not filter by disallowed query params', async () => {
+    test('Should not filter by disallowed query params', async () => {
       const res = await request(app).get('/commits').query({
         createdAt: '2020-06-29T03:34:00.000Z',
       });
@@ -83,7 +84,7 @@ describe('Commits endpoints', () => {
       expect(res.body).toHaveProperty('error');
     });
 
-    test('it should not filter by invalid query values', async () => {
+    test('Should not filter by invalid query values', async () => {
       const res = await request(app).get('/commits').query({
         customerId: 'invalid-customer-id-type',
       });

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -21,7 +21,7 @@ import customerFixtures from '../fixtures/customers';
 
 describe('Customers endpoints', () => {
   describe('GET /customers', () => {
-    test('it should fetch a single customer', async () => {
+    test('Should fetch a single customer', async () => {
       const expectedCustomerData = customerFixtures.responseData?.[0];
       const customerId = expectedCustomerData.id;
 

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -23,7 +23,7 @@ describe('Customers endpoints', () => {
   describe('GET /customers', () => {
     test('it should fetch a single customer', async () => {
       const expectedCustomerData = customerFixtures.responseData?.[0];
-      const customerId = customerFixtures.ids?.[0];
+      const customerId = expectedCustomerData.id;
 
       const res = await request(app).get(`/customers/${customerId}`);
 

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -20,12 +20,14 @@ import app from '../../src';
 import customerFixtures from '../fixtures/customers';
 
 describe('Customers endpoints', () => {
-  test('it should fetch a single customer', async () => {
-    const expectedCustomerData = customerFixtures.responseData?.[0];
-    const customerId = customerFixtures.ids?.[0];
+  describe('GET /customers', () => {
+    test('it should fetch a single customer', async () => {
+      const expectedCustomerData = customerFixtures.responseData?.[0];
+      const customerId = customerFixtures.ids?.[0];
 
-    const res = await request(app).get(`/customers/${customerId}`);
+      const res = await request(app).get(`/customers/${customerId}`);
 
-    expect(res.body).toMatchObject(expectedCustomerData);
+      expect(res.body).toMatchObject(expectedCustomerData);
+    });
   });
 });

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -21,14 +21,11 @@ import customerFixtures from '../fixtures/customers';
 
 describe('Customers endpoints', () => {
   test('it should fetch a single customer', async () => {
-    const expectedCustomerData = customerFixtures.data?.[0];
+    const expectedCustomerData = customerFixtures.responseData?.[0];
     const customerId = customerFixtures.ids?.[0];
 
     const res = await request(app).get(`/customers/${customerId}`);
 
-    expect(res.body).toMatchObject({
-      id: customerId,
-      ...expectedCustomerData,
-    });
+    expect(res.body).toMatchObject(expectedCustomerData);
   });
 });


### PR DESCRIPTION
Closes #109 

# Changes
- Add endpoint to get all commits that accept query parameters "listingId" and "customerId"
- Added tests for commits getter

**Not in this PR:**
-  Handling of proper error codes, added as a TODO.

# Testing
Invalid query param:
![Screenshot 2020-07-08 at 2 53 54 PM](https://user-images.githubusercontent.com/25261058/86889969-34b32200-c12f-11ea-851c-85d9049bb59b.png)

Invalid query value:
![Screenshot 2020-07-08 at 2 54 29 PM](https://user-images.githubusercontent.com/25261058/86889981-37157c00-c12f-11ea-9e3c-0b3a032de98f.png)

Non-existent id provided:
![image](https://user-images.githubusercontent.com/25261058/86890345-bd31c280-c12f-11ea-8e65-9dc2c3868f65.png)

Successful case
![Screenshot 2020-07-08 at 2 54 11 PM](https://user-images.githubusercontent.com/25261058/86889985-38df3f80-c12f-11ea-954f-6ec0029175da.png)

Chaining query params
![image](https://user-images.githubusercontent.com/25261058/86890210-89ef3380-c12f-11ea-8d5f-47a49b7b0c16.png)
