### PR TITLE
Add delete commit endpoint

### DIFF
--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -82,7 +82,7 @@ commitRouter.post(
  */
 commitRouter.delete(
   '/:commitId',
-  // customerAuth,
+  customerAuth,
   async (req: Request, res: Response, next: NextFunction) => {
     const {commitId: commitIdStr} = req.params;
     const commitId = Number(commitIdStr);

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -77,4 +77,24 @@ commitRouter.post(
   }
 );
 
+/**
+ * Handles the delete requests to delete a commit with the specified commitId.
+ */
+commitRouter.delete(
+  '/:commitId',
+  // customerAuth,
+  async (req: Request, res: Response, next: NextFunction) => {
+    const {commitId: commitIdStr} = req.params;
+    const commitId = Number(commitIdStr);
+
+    try {
+      await commitService.deleteCommit(commitId);
+      res.sendStatus(204);
+      // TODO: Add error handling with the appropriate response codes.
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
 export default commitRouter;

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -88,6 +88,10 @@ commitRouter.delete(
     const commitId = Number(commitIdStr);
 
     try {
+      if (Number.isNaN(commitId)) {
+        throw new Error('Invalid commitId params.');
+      }
+
       await commitService.deleteCommit(commitId);
       res.sendStatus(204);
       // TODO: Add error handling with the appropriate response codes.

--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -33,6 +33,10 @@ customerRouter.get(
     const customerId = Number(customerIdStr);
 
     try {
+      if (Number.isNaN(customerId)) {
+        throw new Error('Invalid customerId params.');
+      }
+
       const customer = await customerService.getCustomer(customerId);
       res.send(customer);
     } catch (error) {

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -103,14 +103,19 @@ const addCommit = async (
 
 /**
  * Deletes the commit with the specified commitId.
- * An error would be thrown if commit does not already exist, and if deletion fails.
+ * An error would be thrown if commit does not already exist,
+ * or if the commit is not ONGOING,
+ * or if deletion fails.
  * @param commitId Id of the commit to be deleted
  */
 const deleteCommit = async (commitId: number) => {
   const commit = await commitStorage.getCommit(commitId);
-  const commitListing = await listingStorage.getListing(commit.listingId);
 
-  return commitStorage.deleteCommit(commitId, commitListing.id);
+  if (commit.commitStatus !== 'ongoing') {
+    throw new Error('Only ongoing commits are allowed to be deleted.');
+  }
+
+  return commitStorage.deleteCommit(commitId, commit.listingId);
 };
 
 export default {getAllCommits, addCommit, deleteCommit};

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -94,11 +94,23 @@ const addCommit = async (
     );
   }
 
-  return await commitStorage.addCommit({
+  return commitStorage.addCommit({
     ...DEFAULT_COMMIT_PAYLOAD,
     ...commitData,
     createdAt: new Date(),
   });
 };
 
-export default {getAllCommits, addCommit};
+/**
+ * Deletes the commit with the specified commitId.
+ * An error would be thrown if commit does not already exist, and if deletion fails.
+ * @param commitId Id of the commit to be deleted
+ */
+const deleteCommit = async (commitId: number) => {
+  const commit = await commitStorage.getCommit(commitId);
+  const commitListing = await listingStorage.getListing(commit.listingId);
+
+  return commitStorage.deleteCommit(commitId, commitListing.id);
+};
+
+export default {getAllCommits, addCommit, deleteCommit};

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -16,7 +16,12 @@
 
 import {COMMIT_KIND, LISTING_KIND} from '../constants/kinds';
 import {Filter, CommitResponse, CommitPayload} from '../interfaces';
-import {get, getAll, insertAndUpdateRelatedEntity} from './datastore';
+import {
+  get,
+  getAll,
+  insertAndUpdateRelatedEntity,
+  deleteAndUpdateRelatedEntity,
+} from './datastore';
 
 /**
  * Gets a commit with the specified id from datastore.
@@ -55,4 +60,25 @@ const addCommit = async (commit: CommitPayload): Promise<CommitResponse> => {
   return getCommit(commitId);
 };
 
-export default {getCommit, getAllCommits, addCommit};
+/**
+ * Deletes a commit with the specified id from datastore.
+ * Throws an error if deleting is not successful.
+ * @param commitId Id of the commit to be deleted
+ * @param listingId Id of the listing affected
+ */
+const deleteCommit = async (commitId: number, listingId: number) =>
+  await deleteAndUpdateRelatedEntity(
+    COMMIT_KIND,
+    commitId,
+    LISTING_KIND,
+    listingId,
+    [
+      {
+        property: 'numCommits',
+        op: 'subtract',
+        value: 1,
+      },
+    ]
+  );
+
+export default {getCommit, getAllCommits, addCommit, deleteCommit};

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -94,7 +94,7 @@ const updateData = (original: StringKeyObject, updateRule: UpdateRule) => {
 };
 
 /**
- * Inserts an entity and update a related entity in the same transaction.
+ * Inserts an entity and updates a related entity in the same transaction.
  * Returns the id of the entity that is inserted,
  * @param kindToInsert Kind of the entity to be inserted
  * @param dataToInsert Data of the entity to be inserted
@@ -136,7 +136,7 @@ export const insertAndUpdateRelatedEntity = async (
 };
 
 /**
- * Deletes an entity and update a related entity in the same transaction.
+ * Deletes an entity and updates a related entity in the same transaction.
  * @param kindToDelete Kind of the entity to be deleted
  * @param idToDelete Id of the entity to be deleted
  * @param relatedKindToUpdate Kind of the related entity to be updated


### PR DESCRIPTION
Closes #111 

# Changes
- Added endpoint to delete commits
- Endpoint contains customer auth, so need a valid auth token to make the request
- Added `deleteAndUpdateRelatedEntity()` transaction in the datastore layer

**Not in this PR (to be done in future PRs):**
- Ensure that the user is making the request for themselves
- Returning of proper error codes

# Testing
**Deleting a non-existent Id**
![image](https://user-images.githubusercontent.com/25261058/87308461-d9799900-c54d-11ea-9adb-199d42f4c69d.png)

**Deleting an invalid id**
![Screenshot 2020-07-14 at 11 41 19 AM](https://user-images.githubusercontent.com/25261058/87382500-a83eae80-c5c9-11ea-9010-6139bef5b374.png)

**Deleting a non-ongoing listing**
![Screenshot 2020-07-14 at 12 03 24 PM](https://user-images.githubusercontent.com/25261058/87382696-226f3300-c5ca-11ea-820b-2e0ff994332d.png)
![Screenshot 2020-07-14 at 12 03 11 PM](https://user-images.githubusercontent.com/25261058/87382701-24d18d00-c5ca-11ea-8ef1-40cbcf97efc9.png)

**Successful delete**
![Screenshot 2020-07-13 at 8 56 37 PM](https://user-images.githubusercontent.com/25261058/87308060-3e80bf00-c54d-11ea-8c22-2166d6f71353.png)

**Before deleting in Datastore**
![Screenshot 2020-07-13 at 8 56 04 PM](https://user-images.githubusercontent.com/25261058/87308205-74be3e80-c54d-11ea-8eb7-03ba98d8811e.png)

**After deleting in Datastore**
![Screenshot 2020-07-13 at 8 56 59 PM](https://user-images.githubusercontent.com/25261058/87308227-7daf1000-c54d-11ea-8923-358b6c87e074.png)

**Affected listing now has numCommits of 1 instead of 2**
![Screenshot 2020-07-13 at 8 57 26 PM](https://user-images.githubusercontent.com/25261058/87308268-8e5f8600-c54d-11ea-95ba-ecd0c3b62770.png)
