### PR TITLE
Fix listing rows in explore

### DIFF
--- a/web/src/components/customer/explore/ListingCollection.tsx
+++ b/web/src/components/customer/explore/ListingCollection.tsx
@@ -22,6 +22,12 @@ import ListingCard from 'components/common/ListingCard';
 import StrippedCol from 'components/common/StrippedCol';
 import {Listing} from 'interfaces';
 import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+const ListingsContainer = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+`;
 
 interface ListingProps {
   listing: Listing;
@@ -77,11 +83,11 @@ const ListingCollection: React.FC = () => {
   }, []);
 
   return (
-    <div>
+    <ListingsContainer>
       {listings?.map(listing => (
         <ListingItem listing={listing} key={listing.id} />
       ))}
-    </div>
+    </ListingsContainer>
   );
 };
 


### PR DESCRIPTION
# Changes
A really quick fix on the UI problem on Explore page.

Previously, the problem came about when there are listing cards of uneven height because listing cards would try to take up whatever space without trying to "keep to rows". This PR fixes that.

**Before**
![Screenshot 2020-07-15 at 12 38 52 PM](https://user-images.githubusercontent.com/25261058/87504243-b7406200-c698-11ea-9385-cde756f8f860.png)

**After**
![Screenshot 2020-07-15 at 12 38 39 PM](https://user-images.githubusercontent.com/25261058/87504252-bc9dac80-c698-11ea-93ef-6c70d250b8b4.png)
