### PR TITLE
Only allow unique commits to be created

### DIFF
--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -100,14 +100,17 @@ const addCommit = async (
     {
       property: 'listingId',
       value: Number(commitData.listingId),
-    }
+    },
   ];
 
-  return commitStorage.addCommit({
-    ...DEFAULT_COMMIT_PAYLOAD,
-    ...commitData,
-    createdAt: new Date(),
-  }, uniqueProperties);
+  return commitStorage.addCommit(
+    {
+      ...DEFAULT_COMMIT_PAYLOAD,
+      ...commitData,
+      createdAt: new Date(),
+    },
+    uniqueProperties
+  );
 };
 
 /**

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -95,11 +95,11 @@ const addCommit = async (
   const uniqueProperties = [
     {
       property: 'customerId',
-      value: commitData.customerId,
+      value: Number(commitData.customerId),
     },
     {
       property: 'listingId',
-      value: commitData.listingId,
+      value: Number(commitData.listingId),
     }
   ];
 

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -91,11 +91,23 @@ const addCommit = async (
     );
   }
 
+  // Ensure that another commit between the customer and listing does not already exist.
+  const uniqueProperties = [
+    {
+      property: 'customerId',
+      value: commitData.customerId,
+    },
+    {
+      property: 'listingId',
+      value: commitData.listingId,
+    }
+  ];
+
   return commitStorage.addCommit({
     ...DEFAULT_COMMIT_PAYLOAD,
     ...commitData,
     createdAt: new Date(),
-  });
+  }, uniqueProperties);
 };
 
 /**

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -38,12 +38,13 @@ const getAllCommits = async (filters?: Filter[]): Promise<CommitResponse[]> =>
   getAll(COMMIT_KIND, filters);
 
 /**
- * Adds a commit with the specified data to datastore.
+ * Adds a unique commit with the specified data to datastore.
  * Returns the added commit if adding is successful.
  * Throws an error if adding is not successful.
  * @param commit Data of the commit to be added
+ * @param uniqueProperties The properties that should be unique to the commit
  */
-const addCommit = async (commit: CommitPayload): Promise<CommitResponse> => {
+const addCommit = async (commit: CommitPayload, uniqueProperties?: Filter[]): Promise<CommitResponse> => {
   const commitId = await insertAndUpdateRelatedEntity(
     COMMIT_KIND,
     commit,
@@ -55,7 +56,8 @@ const addCommit = async (commit: CommitPayload): Promise<CommitResponse> => {
         op: 'add',
         value: 1,
       },
-    ]
+    ],
+    uniqueProperties,
   );
   return getCommit(commitId);
 };

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -19,7 +19,7 @@ import {Filter, CommitResponse, CommitPayload} from '../interfaces';
 import {
   get,
   getAll,
-  insertAndUpdateRelatedEntity,
+  addAndUpdateRelatedEntity,
   deleteAndUpdateRelatedEntity,
 } from './datastore';
 
@@ -45,7 +45,7 @@ const getAllCommits = async (filters?: Filter[]): Promise<CommitResponse[]> =>
  * @param uniqueProperties The properties that should be unique to the commit
  */
 const addCommit = async (commit: CommitPayload, uniqueProperties?: Filter[]): Promise<CommitResponse> => {
-  const commitId = await insertAndUpdateRelatedEntity(
+  const commitId = await addAndUpdateRelatedEntity(
     COMMIT_KIND,
     commit,
     LISTING_KIND,

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -44,7 +44,10 @@ const getAllCommits = async (filters?: Filter[]): Promise<CommitResponse[]> =>
  * @param commit Data of the commit to be added
  * @param uniqueProperties The properties that should be unique to the commit
  */
-const addCommit = async (commit: CommitPayload, uniqueProperties?: Filter[]): Promise<CommitResponse> => {
+const addCommit = async (
+  commit: CommitPayload,
+  uniqueProperties?: Filter[]
+): Promise<CommitResponse> => {
   const commitId = await addAndUpdateRelatedEntity(
     COMMIT_KIND,
     commit,
@@ -57,7 +60,7 @@ const addCommit = async (commit: CommitPayload, uniqueProperties?: Filter[]): Pr
         value: 1,
       },
     ],
-    uniqueProperties,
+    uniqueProperties
   );
   return getCommit(commitId);
 };

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -38,7 +38,9 @@ const getAllCommits = async (filters?: Filter[]): Promise<CommitResponse[]> =>
   getAll(COMMIT_KIND, filters);
 
 /**
- * Adds a unique commit with the specified data to datastore.
+ * Adds a commit with the specified data to datastore.
+ * If uniqueProperties is specified, adding will only occur if an existing commit
+ * with the same unique properties don't already exist.
  * Returns the added commit if adding is successful.
  * Throws an error if adding is not successful.
  * @param commit Data of the commit to be added

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -84,10 +84,10 @@ const getCustomerWithGpayId = async (
 const addCustomer = async (
   customer: CustomerPayload
 ): Promise<CustomerResponse> => {
-  const customerId = await add(CUSTOMER_KIND, customer, {
+  const customerId = await add(CUSTOMER_KIND, customer, [{
     property: 'gpayId',
     value: customer.gpayId,
-  });
+  }]);
   return getCustomer(customerId);
 };
 

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -84,10 +84,12 @@ const getCustomerWithGpayId = async (
 const addCustomer = async (
   customer: CustomerPayload
 ): Promise<CustomerResponse> => {
-  const customerId = await add(CUSTOMER_KIND, customer, [{
-    property: 'gpayId',
-    value: customer.gpayId,
-  }]);
+  const customerId = await add(CUSTOMER_KIND, customer, [
+    {
+      property: 'gpayId',
+      value: customer.gpayId,
+    },
+  ]);
   return getCustomer(customerId);
 };
 

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -87,7 +87,9 @@ const uniqueInsertInTransaction = async (
   });
   const [queryRes] = await transaction.runQuery(query);
   if (queryRes.length > 0) {
-    const properties = uniqueProperties.map(unique => unique.property).join(', ');
+    const properties = uniqueProperties
+      .map(unique => unique.property)
+      .join(', ');
     throw new Error(
       `Another entity with the same ${properties} already exists.`
     );
@@ -138,7 +140,7 @@ export const addAndUpdateRelatedEntity = async (
   relatedKindToUpdate: string,
   relatedIdToUpdate: number,
   updateRules: UpdateRule[],
-  uniqueProperties?: Filter[],
+  uniqueProperties?: Filter[]
 ): Promise<number> => {
   const transaction = datastore.transaction();
 
@@ -151,7 +153,12 @@ export const addAndUpdateRelatedEntity = async (
     await transaction.run();
 
     if (uniqueProperties) {
-      await uniqueInsertInTransaction(transaction, kindToInsert, entityToInsert, uniqueProperties);
+      await uniqueInsertInTransaction(
+        transaction,
+        kindToInsert,
+        entityToInsert,
+        uniqueProperties
+      );
     } else {
       transaction.insert(entityToInsert);
     }
@@ -228,7 +235,12 @@ const insertUniqueEntity = async (
 
   try {
     await transaction.run();
-    await uniqueInsertInTransaction(transaction, kind, entity, uniqueProperties);
+    await uniqueInsertInTransaction(
+      transaction,
+      kind,
+      entity,
+      uniqueProperties
+    );
     await transaction.commit();
   } catch (err) {
     await transaction.rollback();

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -94,7 +94,7 @@ const updateData = (original: StringKeyObject, updateRule: UpdateRule) => {
 };
 
 /**
- * Inserts an entity and updates a related entity in the same transaction.
+ * A Datastore wrapper that inserts an entity and updates a related entity in the same transaction.
  * Returns the id of the entity that is inserted.
  * If uniqueProperties are specified,
  * An error is thrown if an entity with the same set of unique properties already exists.
@@ -104,7 +104,7 @@ const updateData = (original: StringKeyObject, updateRule: UpdateRule) => {
  * @param updateRules Rules to update the related entity
  * @param uniqueProperties The properties that should be unique for the specified kindToInsert
  */
-export const insertAndUpdateRelatedEntity = async (
+export const addAndUpdateRelatedEntity = async (
   kindToInsert: string,
   dataToInsert: object,
   relatedKindToUpdate: string,

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -37,7 +37,7 @@ const addMerchant = async (
     property: 'firebaseUid',
     value: merchant.firebaseUid,
   };
-  const merchantId = await add(MERCHANT_KIND, merchant, uniqueFirebaseUid);
+  const merchantId = await add(MERCHANT_KIND, merchant, [uniqueFirebaseUid]);
   return getMerchant(merchantId);
 };
 


### PR DESCRIPTION
Merge after #131 

# Changes
- Previously, we are able to create multiple commits with the same `customerId` and `listingId`. This is not desirable, and we should enforce in the insertion transaction that another commit with the same `customerId` and `listingId` should not already exist.
- Added `uniqueInsertInTransaction` in datastore layer to refactor out unique insertion logic.

# Testing
![Screenshot 2020-07-16 at 3 31 27 PM](https://user-images.githubusercontent.com/25261058/87650774-c6044300-c784-11ea-9b6e-d9959dbc41b6.png)

