### PR TITLE
Add basic my commits page

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -74,8 +74,13 @@ const deleteWithAuth = async (endpoint: string, token: string) => {
  */
 const query = async (
   endpoint: string,
-  queryParams: Record<string, string>
+  queryParams: Record<string, any>
 ): Promise<Response> => {
+  const strParams: Record<string, string> = {};
+  Object.keys(queryParams).forEach(
+    key => (strParams[key] = String(queryParams[key]))
+  );
+
   const url = new URL(endpoint);
   const params = new URLSearchParams(queryParams).toString();
   url.search = params;
@@ -136,16 +141,11 @@ export const getListing = async (listingId: number): Promise<Listing> => {
  * @param commitQuery Query params of the request
  */
 export const getCommits = async (
-  commitQuery: CommitQuery
+  commitQuery: Partial<CommitQuery>
 ): Promise<Commit[]> => {
-  const queryParams = {
-    listingId: String(commitQuery.listingId),
-    customerId: String(commitQuery.customerId),
-  };
-
   const res = await query(
     `${process.env.REACT_APP_SERVER_URL}/commits/`,
-    queryParams
+    commitQuery
   );
   return res.json();
 };

--- a/web/src/components/customer/Routes.tsx
+++ b/web/src/components/customer/Routes.tsx
@@ -23,6 +23,7 @@ const ExplorePage = lazy(() => import('components/customer/explore'));
 const ListingDetailsPage = lazy(() =>
   import('components/customer/listing-details')
 );
+const MyCommitsPage = lazy(() => import('components/customer/my-commits'));
 
 const CustomerRoutes: React.FC = () => {
   const {path} = useRouteMatch();
@@ -31,9 +32,11 @@ const CustomerRoutes: React.FC = () => {
       <CustomerProvider>
         <Route exact path={path} component={ExplorePage} />
         <Route
+          exact
           path={`${path}listing/:listingId`}
           component={ListingDetailsPage}
         />
+        <Route exact path={`${path}commits`} component={MyCommitsPage} />
       </CustomerProvider>
     </Switch>
   );

--- a/web/src/components/customer/explore/index.tsx
+++ b/web/src/components/customer/explore/index.tsx
@@ -21,6 +21,7 @@ import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
 import ListingCollection from 'components/customer/explore/ListingCollection';
 import Button from 'muicss/lib/react/button';
 import Container from 'muicss/lib/react/container';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 const PageContainer = styled(Container)`
@@ -44,6 +45,11 @@ const CustomerExplorePage: React.FC = () => {
       <CommitsBadgeContainer>
         <CommitsBadge />
       </CommitsBadgeContainer>
+      <Link to="/commits">
+        <Button color="primary" variant="flat">
+          View My Commits
+        </Button>
+      </Link>
       <h1>Explore</h1>
       <ListingCollection />
       <Button color="primary" onClick={handleGetIdentity}>

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {Commit, GroupedCommits} from 'interfaces';
+import styled from 'styled-components';
+
+const CommitsContainer = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+
+  word-break: break-word;
+
+  & > h2 {
+    font-size: 1.4em;
+  }
+`;
+interface CommitSectionProps {
+  commits: Commit[];
+}
+
+// TODO: Change this to show horizontal listing cards
+const CommitSection: React.FC<CommitSectionProps> = ({commits}) => (
+  <>{JSON.stringify(commits)}</>
+);
+
+interface CommitsProps {
+  commits: GroupedCommits;
+}
+
+/**
+ * Contains the content of the My Commits page.
+ */
+const Commits: React.FC<CommitsProps> = ({
+  commits: {ongoing, successful, paid, completed, unsuccessful},
+}) => (
+  <CommitsContainer>
+    <h2>Awaiting Payment</h2>
+    {successful && <CommitSection commits={successful} />}
+    <h2>Ongoing</h2>
+    {ongoing && <CommitSection commits={ongoing} />}
+    <h2>History</h2>
+    {paid && <CommitSection commits={paid} />}
+    {completed && <CommitSection commits={completed} />}
+    {unsuccessful && <CommitSection commits={unsuccessful} />}
+  </CommitsContainer>
+);
+
+export default Commits;

--- a/web/src/components/customer/my-commits/index.tsx
+++ b/web/src/components/customer/my-commits/index.tsx
@@ -21,10 +21,11 @@ import BackButton from 'components/common/BackButton';
 import CommitsBadge from 'components/common/CommitsBadge';
 import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
 import Commits from 'components/customer/my-commits/Commits';
-import {Commit, GroupedCommits} from 'interfaces';
+import {GroupedCommits} from 'interfaces';
 import Container from 'muicss/lib/react/container';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
+import {groupByCommitStatus} from 'utils/commit-status';
 
 const PageContainer = styled(Container)`
   padding-top: 20px;
@@ -36,19 +37,6 @@ const PageContainer = styled(Container)`
 const CommitsBadgeContainer = styled.div`
   align-self: flex-end;
 `;
-
-/**
- * Groups commits by their commit status.
- * @param commits Commits to be grouped
- */
-const groupByCommitStatus = (commits: Commit[]): GroupedCommits =>
-  commits.reduce(
-    (result, commit) => ({
-      ...result,
-      [commit.commitStatus]: [...(result[commit.commitStatus] || []), commit],
-    }),
-    {} as GroupedCommits
-  );
 
 /**
  * Page containing all the commits of the current customer.

--- a/web/src/components/customer/my-commits/index.tsx
+++ b/web/src/components/customer/my-commits/index.tsx
@@ -37,6 +37,10 @@ const CommitsBadgeContainer = styled.div`
   align-self: flex-end;
 `;
 
+/**
+ * Groups commits by their commit status.
+ * @param commits Commits to be grouped
+ */
 const groupByCommitStatus = (commits: Commit[]): GroupedCommits =>
   commits.reduce(
     (result, commit) => ({

--- a/web/src/components/customer/my-commits/index.tsx
+++ b/web/src/components/customer/my-commits/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useState, useEffect} from 'react';
+
+import {getCommits} from 'api';
+import BackButton from 'components/common/BackButton';
+import CommitsBadge from 'components/common/CommitsBadge';
+import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
+import Commits from 'components/customer/my-commits/Commits';
+import {Commit, GroupedCommits} from 'interfaces';
+import Container from 'muicss/lib/react/container';
+import {useHistory} from 'react-router-dom';
+import styled from 'styled-components';
+
+const PageContainer = styled(Container)`
+  padding-top: 20px;
+
+  display: flex;
+  flex-direction: column;
+`;
+
+const CommitsBadgeContainer = styled.div`
+  align-self: flex-end;
+`;
+
+const groupByCommitStatus = (commits: Commit[]): GroupedCommits =>
+  commits.reduce(
+    (result, commit) => ({
+      ...result,
+      [commit.commitStatus]: [...(result[commit.commitStatus] || []), commit],
+    }),
+    {} as GroupedCommits
+  );
+
+/**
+ * Page containing all the commits of the current customer.
+ */
+const MyCommitsPage: React.FC = () => {
+  const {customer, getCustomerWithLogin} = useCustomerContext();
+
+  const [commits, setCommits] = useState<GroupedCommits>({});
+
+  const history = useHistory();
+
+  useEffect(() => {
+    const fetchCommits = async () => {
+      if (customer === undefined) {
+        await getCustomerWithLogin();
+        return;
+      }
+
+      const fetchedCommits = await getCommits({
+        customerId: customer.id,
+      });
+      setCommits(groupByCommitStatus(fetchedCommits));
+    };
+
+    fetchCommits();
+  }, [customer, getCustomerWithLogin]);
+
+  const handleBack = () => history.goBack();
+
+  return (
+    <PageContainer>
+      <BackButton pos="absolute" onClick={handleBack} />
+      <CommitsBadgeContainer>
+        <CommitsBadge />
+      </CommitsBadgeContainer>
+      <h1>My Commits</h1>
+      <Commits commits={commits} />
+    </PageContainer>
+  );
+};
+
+export default MyCommitsPage;

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -97,6 +97,13 @@ export interface Commit extends CommitPayload {
 }
 
 /**
+ * GroupedCommits type of commits grouped by their commit status.
+ */
+export type GroupedCommits = {
+  [key in CommitStatus]?: Commit[];
+};
+
+/**
  * CustomerPayload Interface that contains the fields of the payload that
  * would be sent to the server.
  */

--- a/web/src/utils/commit-status/commit-status.test.ts
+++ b/web/src/utils/commit-status/commit-status.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Commit, GroupedCommits} from 'interfaces';
+import {groupByCommitStatus} from 'utils/commit-status';
+
+describe('groupByCommitStatus', () => {
+  const ongoingCommits: Commit[] = [
+    {
+      id: 1,
+      createdAt: new Date(),
+      listingId: 1,
+      customerId: 1,
+      commitStatus: 'ongoing',
+    },
+    {
+      id: 2,
+      createdAt: new Date(),
+      listingId: 1,
+      customerId: 1,
+      commitStatus: 'ongoing',
+    },
+  ];
+
+  const successfulCommits: Commit[] = [
+    {
+      id: 3,
+      createdAt: new Date(),
+      listingId: 1,
+      customerId: 1,
+      commitStatus: 'successful',
+    },
+  ];
+
+  const paidCommits: Commit[] = [
+    {
+      id: 1,
+      createdAt: new Date(),
+      listingId: 1,
+      customerId: 1,
+      commitStatus: 'paid',
+    },
+  ];
+
+  test('it should group by commit status', () => {
+    const commits = [...ongoingCommits, ...successfulCommits, ...paidCommits];
+
+    const expectedValue: GroupedCommits = {
+      ongoing: ongoingCommits,
+      successful: successfulCommits,
+      paid: paidCommits,
+    };
+
+    expect(groupByCommitStatus(commits)).toEqual(expectedValue);
+  });
+});

--- a/web/src/utils/commit-status/index.ts
+++ b/web/src/utils/commit-status/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Commit, GroupedCommits} from 'interfaces';
+
+/**
+ * Groups commits by their commit status.
+ * @param commits Commits to be grouped
+ */
+export const groupByCommitStatus = (commits: Commit[]): GroupedCommits =>
+  commits.reduce((result, commit) => {
+    const currValue = result[commit.commitStatus] || [];
+    currValue.push(commit);
+    result[commit.commitStatus] = currValue;
+    return result;
+  }, {} as GroupedCommits);


### PR DESCRIPTION
To be merged after #138 
Part of #14 

# Changes
- Added basic My Commits page that shows the commit JSON 
- Added button (unstyled yet) on Explore page to link to My Commits page

![Screenshot 2020-07-17 at 9 25 41 PM](https://user-images.githubusercontent.com/25261058/87900230-51801b80-ca86-11ea-9367-fcc7192dc9ea.png)
