### PR TITLE
Refactor out CommitContext

### DIFF
--- a/web/src/components/customer/listing-details/ActionBar.tsx
+++ b/web/src/components/customer/listing-details/ActionBar.tsx
@@ -16,7 +16,7 @@
 
 import React, {useState, useEffect, useCallback} from 'react';
 
-import {useListingDetailsContext} from 'components/customer/listing-details/contexts/ListingDetailsContext';
+import {useCommitContext} from 'components/customer/listing-details/contexts/CommitContext';
 import {CommitStatus} from 'interfaces';
 import Button from 'muicss/lib/react/button';
 import Container from 'muicss/lib/react/container';
@@ -79,7 +79,7 @@ const commitStatusToButtonState = (
  * ActionBar that contains a button to commit/uncommit/pay a listing.
  */
 const ActionBar: React.FC = () => {
-  const {commitStatus, onCommit, onUncommit} = useListingDetailsContext();
+  const {commitStatus, onCommit, onUncommit} = useCommitContext();
 
   const [buttonState, setButtonState] = useState<ActionButtonState>('initial');
   const [button, setButton] = useState(<></>);

--- a/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
+++ b/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
@@ -18,11 +18,10 @@ import React, {useState, useEffect} from 'react';
 
 import CommitsBadge from 'components/common/CommitsBadge';
 import MobilePrompt from 'components/common/MobilePrompt';
+import {useCommitFeedbackPromptContext} from 'components/customer/listing-details/contexts/CommitFeedbackPromptContext';
 
 import {ReactComponent as CelebrateSvg} from 'assets/celebrate.svg';
 import {ReactComponent as PaymentSvg} from 'assets/customer/payment.svg';
-
-import {useCommitFeedbackPromptContext} from './contexts/CommitFeedbackPromptContext';
 
 interface PromptProps {
   isVisible: boolean;

--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useContext, useState, useEffect} from 'react';
+
+import {getCommits, addCommit, deleteCommit} from 'api';
+import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
+import {useCommitFeedbackPromptContext} from 'components/customer/listing-details/contexts/CommitFeedbackPromptContext';
+import {CommitStatus} from 'interfaces';
+
+type ContextType =
+  | {
+      commitStatus: CommitStatus | undefined;
+      onCommit: () => Promise<void>;
+      onUncommit: () => Promise<void>;
+    }
+  | undefined;
+
+const CommitContext = React.createContext<ContextType>(undefined);
+
+/**
+ * useContext hook that ensures it is used within a CommitContext.
+ */
+const useCommitContext = () => {
+  const context = useContext(CommitContext);
+  if (context === undefined) {
+    throw new Error('useCommitContext must be used within a CommitContext');
+  }
+  return context;
+};
+
+interface CommitContextProps {
+  listingId: number;
+}
+
+/**
+ * CommitContextProvider provider with stateful commit details.
+ */
+const CommitContextProvider: React.FC<CommitContextProps> = ({
+  children,
+  listingId,
+}) => {
+  const {
+    customer,
+    idToken,
+    getCustomerWithLogin,
+    refetchCustomer,
+  } = useCustomerContext();
+
+  const {onOpen: onOpenPrompt} = useCommitFeedbackPromptContext();
+
+  const [commitStatus, setCommitStatus] = useState<CommitStatus>();
+  const [commitId, setCommitId] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (customer === undefined) {
+      setCommitStatus(undefined);
+      return;
+    }
+
+    const fetchCommit = async () => {
+      const [commit] = await getCommits({
+        listingId,
+        customerId: customer.id,
+      });
+      if (commit !== undefined) {
+        setCommitId(commit.id);
+        setCommitStatus(commit.commitStatus);
+      }
+    };
+    fetchCommit();
+  }, [listingId, customer]);
+
+  const onCommit = async () => {
+    const customer = await getCustomerWithLogin();
+
+    if (customer === undefined || idToken === undefined) {
+      // TODO: Handle case when user refuse to login even after prompted
+      return;
+    }
+
+    const commit = await addCommit(
+      {
+        listingId,
+        customerId: customer.id,
+      },
+      idToken
+    );
+    // TODO: Handle addition error
+    setCommitId(commit.id);
+    await refetchCustomer();
+    setCommitStatus(commit.commitStatus);
+    onOpenPrompt('successful-commit');
+  };
+
+  const onUncommit = async () => {
+    if (commitId === undefined) {
+      return;
+    }
+
+    const customer = await getCustomerWithLogin();
+
+    if (customer === undefined || idToken === undefined) {
+      // TODO: Handle case when user refuse to login even after prompted
+      return;
+    }
+
+    await deleteCommit(commitId, idToken);
+    // TODO: Handle deletion error
+    setCommitId(undefined);
+    await refetchCustomer();
+    setCommitStatus(undefined);
+  };
+
+  const value = {
+    commitStatus,
+    onCommit,
+    onUncommit,
+  };
+
+  return (
+    <CommitContext.Provider value={value}>{children}</CommitContext.Provider>
+  );
+};
+
+export default CommitContextProvider;
+export {useCommitContext};

--- a/web/src/components/customer/listing-details/index.tsx
+++ b/web/src/components/customer/listing-details/index.tsx
@@ -20,6 +20,7 @@ import BackButton from 'components/common/BackButton';
 import CommitsBadge from 'components/common/CommitsBadge';
 import ActionBar from 'components/customer/listing-details/ActionBar';
 import CommitStatusPrompt from 'components/customer/listing-details/CommitFeedbackPrompt';
+import CommitContext from 'components/customer/listing-details/contexts/CommitContext';
 import CommitFeedbackPromptContext from 'components/customer/listing-details/contexts/CommitFeedbackPromptContext';
 import ListingDetailsContext from 'components/customer/listing-details/contexts/ListingDetailsContext';
 import ListingDetails from 'components/customer/listing-details/ListingDetails';
@@ -60,16 +61,18 @@ const ListingDetailsPage: React.FC = () => {
 
   return (
     <CommitFeedbackPromptContext>
-      <ListingDetailsContext listingId={listingId}>
-        <PageContainer>
-          <BackButton pos="absolute" onClick={handleBack} />
-          <CommitsBadge pos="absolute" />
-          <ContentContainer>
-            <ListingDetails />
-          </ContentContainer>
-          <ActionBar />
-        </PageContainer>
-      </ListingDetailsContext>
+      <CommitContext listingId={listingId}>
+        <ListingDetailsContext listingId={listingId}>
+          <PageContainer>
+            <BackButton pos="absolute" onClick={handleBack} />
+            <CommitsBadge pos="absolute" />
+            <ContentContainer>
+              <ListingDetails />
+            </ContentContainer>
+            <ActionBar />
+          </PageContainer>
+        </ListingDetailsContext>
+      </CommitContext>
       <CommitStatusPrompt />
     </CommitFeedbackPromptContext>
   );


### PR DESCRIPTION
To be merged after #138 
Refactoring PR, no behavioural changes from #138

# Changes
- After #138, `ListingDetailsContext` seems to be in charge of too many things (it touched on listings, commit, customer). This PR moves out all commit related logic (which includes updating of customer) to `CommitContext`. `ListingDetailsContext` is now just in charge of listing & page related logic. 