### PR TITLE
Add pay for commit endpoint

### DIFF
--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -78,6 +78,33 @@ commitRouter.post(
 );
 
 /**
+ * Handles the post requests to pay for commits.
+ */
+commitRouter.post(
+  '/:commitId/pay',
+  // customerAuth,
+  async (req: Request, res: Response, next: NextFunction) => {
+    const {commitId: commitIdStr} = req.params;
+    const commitId = Number(commitIdStr);
+
+    // TODO: Parse req.body json to make it CommitPaymentRequest type in runtime.
+    // TODO: Ensure that the commit belongs to the authenticated customer.
+
+    try {
+      if (Number.isNaN(commitId)) {
+        throw new Error('Invalid commitId params.');
+      }
+
+      const commit = await commitService.payForCommit(commitId, req.body);
+      res.status(200).json(commit);
+      // TODO: Add error handling with the appropriate response codes.
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+/**
  * Handles the delete requests to delete a commit with the specified commitId.
  */
 commitRouter.delete(

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -82,7 +82,7 @@ commitRouter.post(
  */
 commitRouter.post(
   '/:commitId/pay',
-  // customerAuth,
+  customerAuth,
   async (req: Request, res: Response, next: NextFunction) => {
     const {commitId: commitIdStr} = req.params;
     const commitId = Number(commitIdStr);

--- a/server/src/constants/default-payload.ts
+++ b/server/src/constants/default-payload.ts
@@ -31,6 +31,8 @@ export const DEFAULT_CUSTOMER_PAYLOAD = {
  */
 export const DEFAULT_COMMIT_PAYLOAD = {
   commitStatus: 'ongoing' as CommitStatus,
+  deliveryAddress: '',
+  deliveryContactNumber: '',
 };
 
 /**

--- a/server/src/constants/default-payload.ts
+++ b/server/src/constants/default-payload.ts
@@ -31,8 +31,11 @@ export const DEFAULT_CUSTOMER_PAYLOAD = {
  */
 export const DEFAULT_COMMIT_PAYLOAD = {
   commitStatus: 'ongoing' as CommitStatus,
-  deliveryAddress: '',
-  deliveryContactNumber: '',
+  fulfilmentDetails: {
+    name: '',
+    address: '',
+    contactNumber: '',
+  },
 };
 
 /**

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -69,12 +69,20 @@ export interface CommitRequest {
 }
 
 /**
+ * FulfilmentDetails Interface that contains the fields of a fulfilment.
+ */
+interface FulfilmentDetails {
+  name: string;
+  address: string;
+  contactNumber: string; // E164 format
+}
+
+/**
  * CommitPaymentRequest Interface that contains the fields that will be provided
  * by the client in the request body.
  */
 export interface CommitPaymentRequest {
-  deliveryAddress: string;
-  deliveryContactNumber: string; // E164 format
+  fulfilmentDetails: FulfilmentDetails;
 }
 
 /**

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -74,7 +74,7 @@ export interface CommitRequest {
  */
 export interface CommitPaymentRequest {
   deliveryAddress: string;
-  deliveryContactNumber: string;
+  deliveryContactNumber: string; // E164 format
 }
 
 /**

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -61,7 +61,7 @@ export interface CommitComputedProperties {
 
 /**
  * CommitRequest Interface that contains the fields that will be provided
- * by the client in the POST/PUT request body.
+ * by the client in the request body to create a Commit.
  */
 export interface CommitRequest {
   customerId: number;
@@ -69,17 +69,33 @@ export interface CommitRequest {
 }
 
 /**
+ * CommitPaymentRequest Interface that contains the fields that will be provided
+ * by the client in the request body.
+ */
+export interface CommitPaymentRequest {
+  deliveryAddress: string;
+  deliveryContactNumber: string;
+}
+
+/**
  * CommitPayload Interface that contains the fields of the payload that
- * would be sent to create a Listing Entity.
+ * would be sent to create a Commit Entity.
  */
 export interface CommitPayload
   extends CommitComputedProperties,
-    CommitRequest {}
+    CommitRequest,
+    CommitPaymentRequest {}
 
 /**
  * Union type of the keys of CommitPayload.
  */
 export type CommitPayloadKey = keyof CommitPayload;
+
+/**
+ * CommitEditPayload Interface that contains the fields of the payload that
+ * would be sent to edit a Commit Entity.
+ */
+export type CommitEditPayload = Partial<CommitPayload>;
 
 /**
  * CommitResponse Interface that contains the fields of the Response that

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -134,12 +134,12 @@ const payForCommit = async (
   }
 
   // TODO: Validate paymentData
-  const editFields: CommitEditPayload = {
+  const fieldsToEdit: CommitEditPayload = {
     ...paymentData,
     commitStatus: 'paid',
   };
 
-  return commitStorage.editCommit(commitId, editFields, commit.listingId);
+  return commitStorage.editCommit(commitId, fieldsToEdit, commit.listingId);
 };
 
 /**

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -22,6 +22,8 @@ import {
   CommitRequest,
   StringKeyObject,
   CommitPayloadKey,
+  CommitPaymentRequest,
+  CommitEditPayload,
 } from '../interfaces';
 import {commitStorage, listingStorage, customerStorage} from '../storage';
 
@@ -114,6 +116,33 @@ const addCommit = async (
 };
 
 /**
+ * Pays for the commit with the specified commitId.
+ * An error will be thrown if the commit is not SUCCESSFUL.
+ * @param commitId Id of the commit to be deleted
+ * @param paymentData Data of the payment request
+ */
+const payForCommit = async (
+  commitId: number,
+  paymentData: CommitPaymentRequest
+) => {
+  // Check that listing exists
+  const commit = await commitStorage.getCommit(commitId);
+
+  // Check that listing is successful
+  if (commit.commitStatus !== 'successful') {
+    throw new Error('Only successful commits can be paid.');
+  }
+
+  // TODO: Validate paymentData
+  const editFields: CommitEditPayload = {
+    ...paymentData,
+    commitStatus: 'paid',
+  };
+
+  return commitStorage.editCommit(commitId, editFields, commit.listingId);
+};
+
+/**
  * Deletes the commit with the specified commitId.
  * An error would be thrown if commit does not already exist,
  * or if the commit is not ONGOING,
@@ -130,4 +159,4 @@ const deleteCommit = async (commitId: number) => {
   return commitStorage.deleteCommit(commitId, commit.listingId);
 };
 
-export default {getAllCommits, addCommit, deleteCommit};
+export default {getAllCommits, addCommit, payForCommit, deleteCommit};

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -87,11 +87,13 @@ const editCommit = async (
   fieldsToEdit: CommitEditPayload,
   affectedListingId: number
 ): Promise<CommitResponse> => {
-  const commitEditRules: UpdateRule[] = Object.keys(fieldsToEdit).map(field => ({
-    property: field,
-    op: 'replace',
-    value: fieldsToEdit[field as keyof CommitEditPayload],
-  }));
+  const commitEditRules: UpdateRule[] = Object.keys(fieldsToEdit).map(
+    field => ({
+      property: field,
+      op: 'replace',
+      value: fieldsToEdit[field as keyof CommitEditPayload],
+    })
+  );
 
   const listingUpdateRules: UpdateRule[] = [];
   if (fieldsToEdit.commitStatus === 'paid') {

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -79,22 +79,22 @@ const addCommit = async (
  * Returns the edited commit data.
  * Throws an error if edit is not successful.
  * @param commitId Id of the commit to be edited
- * @param editFields Fields of the commit to be edited
+ * @param fieldsToEdit Fields of the commit to be edited
  * @param affectedListingId Id of the listing that might be affected
  */
 const editCommit = async (
   commitId: number,
-  editFields: CommitEditPayload,
+  fieldsToEdit: CommitEditPayload,
   affectedListingId: number
 ): Promise<CommitResponse> => {
-  const commitEditRules: UpdateRule[] = Object.keys(editFields).map(field => ({
+  const commitEditRules: UpdateRule[] = Object.keys(fieldsToEdit).map(field => ({
     property: field,
     op: 'replace',
-    value: editFields[field as keyof CommitEditPayload],
+    value: fieldsToEdit[field as keyof CommitEditPayload],
   }));
 
   const listingUpdateRules: UpdateRule[] = [];
-  if (editFields.commitStatus === 'paid') {
+  if (fieldsToEdit.commitStatus === 'paid') {
     listingUpdateRules.push({
       property: 'numPaid',
       op: 'add',

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -15,13 +15,20 @@
  */
 
 import {COMMIT_KIND, LISTING_KIND} from '../constants/kinds';
-import {Filter, CommitResponse, CommitPayload} from '../interfaces';
+import {
+  Filter,
+  CommitResponse,
+  CommitPayload,
+  CommitEditPayload,
+} from '../interfaces';
 import {
   get,
   getAll,
   addAndUpdateRelatedEntity,
   deleteAndUpdateRelatedEntity,
+  editAndUpdateRelatedEntity,
 } from './datastore';
+import {UpdateRule} from './interfaces';
 
 /**
  * Gets a commit with the specified id from datastore.
@@ -68,6 +75,45 @@ const addCommit = async (
 };
 
 /**
+ * Edits a commit with the specified id according to the edit rules.
+ * Returns the edited commit data.
+ * Throws an error if edit is not successful.
+ * @param commitId Id of the commit to be edited
+ * @param editFields Fields of the commit to be edited
+ * @param affectedListingId Id of the listing that might be affected
+ */
+const editCommit = async (
+  commitId: number,
+  editFields: CommitEditPayload,
+  affectedListingId: number
+): Promise<CommitResponse> => {
+  const commitEditRules: UpdateRule[] = Object.keys(editFields).map(field => ({
+    property: field,
+    op: 'replace',
+    value: editFields[field as keyof CommitEditPayload],
+  }));
+
+  const listingUpdateRules: UpdateRule[] = [];
+  if (editFields.commitStatus === 'paid') {
+    listingUpdateRules.push({
+      property: 'numPaid',
+      op: 'add',
+      value: 1,
+    });
+  }
+
+  await editAndUpdateRelatedEntity(
+    COMMIT_KIND,
+    commitId,
+    commitEditRules,
+    LISTING_KIND,
+    affectedListingId,
+    listingUpdateRules
+  );
+  return getCommit(commitId);
+};
+
+/**
  * Deletes a commit with the specified id from datastore.
  * Throws an error if deleting is not successful.
  * @param commitId Id of the commit to be deleted
@@ -88,4 +134,4 @@ const deleteCommit = async (commitId: number, listingId: number) =>
     ]
   );
 
-export default {getCommit, getAllCommits, addCommit, deleteCommit};
+export default {getCommit, getAllCommits, addCommit, editCommit, deleteCommit};


### PR DESCRIPTION
Closes #150

# Changes
- Added endpoint to pay for commits
- Added `editAndUpdateRelatedEntity` to datastore layer,  and refactored out `updateEntityInTransaction` in datastore layer

**TODOs, Not in this PR**
- Ensure that commit belongs to the authenticated customer
- Updating of commit interface on client side to include address and contact number
- Validating of paymentData (#153)
- Updating of customer's address and contact number

# Manual Testing
**Non-existent commit id**
![Screenshot 2020-07-22 at 1 23 56 PM](https://user-images.githubusercontent.com/25261058/88138301-fb46e000-cc1f-11ea-917e-19cfc9f7a132.png)

**Invalid commit id type**
![Screenshot 2020-07-22 at 1 23 45 PM](https://user-images.githubusercontent.com/25261058/88138303-fc780d00-cc1f-11ea-850b-542a68473e5a.png)

**Successful payment**
![image](https://user-images.githubusercontent.com/25261058/88517826-0932a180-d022-11ea-8952-30278e892bf4.png)
**Updated commit after successful payment**
![image](https://user-images.githubusercontent.com/25261058/88517858-1780bd80-d022-11ea-98d9-f1362ab4a71b.png)
**Updated listing after successful payment**
![Screenshot 2020-07-22 at 1 11 27 PM](https://user-images.githubusercontent.com/25261058/88138435-4103a880-cc20-11ea-8577-c862ad58028e.png)

