### PR TITLE
Add basic customer payment flow

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -29,6 +29,7 @@ import {
   ListingPayload,
   MerchantPayload,
   MerchantResponse,
+  CommitPaymentPayload,
 } from 'interfaces';
 
 /**
@@ -202,6 +203,25 @@ export const deleteCommit = async (commitId: number, idToken: string) => {
     `${process.env.REACT_APP_SERVER_URL}/commits/${commitId}`,
     idToken
   );
+};
+
+/**
+ * Pay for a commit with the specified commitId.
+ * @param commitId Id of the commit to pay for
+ * @param paymentData Payment data for the commit
+ * @param idToken Authentication token of customer
+ */
+export const payForCommit = async (
+  commitId: number,
+  paymentData: CommitPaymentPayload,
+  idToken: string
+): Promise<Commit> => {
+  const res = await postWithAuth(
+    `${process.env.REACT_APP_SERVER_URL}/commits/${commitId}/pay`,
+    paymentData,
+    idToken
+  );
+  return res.json();
 };
 
 /**

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -206,7 +206,7 @@ export const deleteCommit = async (commitId: number, idToken: string) => {
 };
 
 /**
- * Pay for a commit with the specified commitId.
+ * Pays for a commit with the specified commitId.
  * @param commitId Id of the commit to pay for
  * @param paymentData Payment data for the commit
  * @param idToken Authentication token of customer

--- a/web/src/components/customer/listing-details/ActionBar.tsx
+++ b/web/src/components/customer/listing-details/ActionBar.tsx
@@ -79,7 +79,7 @@ const commitStatusToButtonState = (
  * ActionBar that contains a button to commit/uncommit/pay a listing.
  */
 const ActionBar: React.FC = () => {
-  const {commitStatus, onCommit, onUncommit} = useCommitContext();
+  const {commitStatus, onCommit, onUncommit, onPayment} = useCommitContext();
 
   const [buttonState, setButtonState] = useState<ActionButtonState>('initial');
   const [button, setButton] = useState(<></>);
@@ -113,12 +113,23 @@ const ActionBar: React.FC = () => {
               Uncommit listing
             </ActionButton>
           );
+        case 'awaitingPayment':
+          return (
+            <ActionButton
+              onClick={() => onClickButton(onPayment)}
+              color="primary"
+            >
+              Pay
+            </ActionButton>
+          );
+        case 'awaitingDelivery':
+          return <ActionButton disabled>Waiting for Delivery</ActionButton>;
         default:
-          // TODO: Deal with other cases of ActionButtonState
+          // TODO: Deal with delivered case ActionButtonState
           return <></>;
       }
     },
-    [onCommit, onUncommit]
+    [onCommit, onUncommit, onPayment]
   );
 
   useEffect(() => {

--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -145,6 +145,7 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
     };
 
     const commit = await payForCommit(commitId, dummyPaymentData, idToken);
+    // TODO: Handle payment error
     await refetchCustomer();
     setCommitStatus(commit.commitStatus);
     onOpenPrompt('successful-payment');

--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -144,7 +144,7 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
         address:
           '3 North Avenue, Maker Maxity, Bandra Kurla Complex, Bandra East, Mumbai, 400051',
         contactNumber: '+912266117150',
-      }
+      },
     };
 
     const commit = await payForCommit(commitId, dummyPaymentData, idToken);

--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -139,9 +139,12 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
 
     // TODO: Ask customer for actual payment data
     const dummyPaymentData: CommitPaymentPayload = {
-      deliveryAddress:
-        '3 North Avenue, Maker Maxity, Bandra Kurla Complex, Bandra East, Mumbai, 400051',
-      deliveryContactNumber: '+912266117150',
+      fulfilmentDetails: {
+        name: 'Shopaholic',
+        address:
+          '3 North Avenue, Maker Maxity, Bandra Kurla Complex, Bandra East, Mumbai, 400051',
+        contactNumber: '+912266117150',
+      }
     };
 
     const commit = await payForCommit(commitId, dummyPaymentData, idToken);

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -48,6 +48,15 @@ export type DeadlineFontSize = Omit<FontSize, 'large'>;
 export type PriceFontSize = Omit<FontSize, 'small'>;
 
 /**
+ * FulfilmentDetails Interface that contains the fields of a fulfilment.
+ */
+interface FulfilmentDetails {
+  name: string;
+  address: string;
+  contactNumber: string; // E164 format
+}
+
+/**
  * Money Interface that represents an amount of money with its currency type.
  * Value = dollars + (cents / 100)
  */
@@ -131,8 +140,7 @@ export interface CommitPayload {
  * would be sent to the server to pay for commits.
  */
 export interface CommitPaymentPayload {
-  deliveryAddress: string;
-  deliveryContactNumber: string;
+  fulfilmentDetails: FulfilmentDetails;
 }
 
 /**

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -127,6 +127,15 @@ export interface CommitPayload {
 }
 
 /**
+ * CommitPaymentPayload Interface that contains the fields of the payload that
+ * would be sent to the server to pay for commits.
+ */
+export interface CommitPaymentPayload {
+  deliveryAddress: string;
+  deliveryContactNumber: string;
+}
+
+/**
  * CommitQuery Interface that contains the fields of the query that
  * would be sent to the server to query for commits.
  */
@@ -135,7 +144,7 @@ export type CommitQuery = CommitPayload;
 /**
  * Commit Interface that contains the fields of a Commit.
  */
-export interface Commit extends CommitPayload {
+export interface Commit extends CommitPayload, CommitPaymentPayload {
   id: number;
   createdAt: Date;
   commitStatus: CommitStatus;

--- a/web/src/utils/commit-status/commit-status.test.ts
+++ b/web/src/utils/commit-status/commit-status.test.ts
@@ -25,8 +25,11 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'ongoing',
-      deliveryAddress: '',
-      deliveryContactNumber: '',
+      fulfilmentDetails: {
+        name: '',
+        address: '',
+        contactNumber: '',
+      },
     },
     {
       id: 2,
@@ -34,8 +37,11 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'ongoing',
-      deliveryAddress: '',
-      deliveryContactNumber: '',
+      fulfilmentDetails: {
+        name: '',
+        address: '',
+        contactNumber: '',
+      },
     },
   ];
 
@@ -46,8 +52,11 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'successful',
-      deliveryAddress: '',
-      deliveryContactNumber: '',
+      fulfilmentDetails: {
+        name: '',
+        address: '',
+        contactNumber: '',
+      },
     },
   ];
 
@@ -58,8 +67,11 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'paid',
-      deliveryAddress: '',
-      deliveryContactNumber: '',
+      fulfilmentDetails: {
+        name: '',
+        address: '',
+        contactNumber: '',
+      },
     },
   ];
 

--- a/web/src/utils/commit-status/commit-status.test.ts
+++ b/web/src/utils/commit-status/commit-status.test.ts
@@ -25,6 +25,8 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'ongoing',
+      deliveryAddress: '',
+      deliveryContactNumber: '',
     },
     {
       id: 2,
@@ -32,6 +34,8 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'ongoing',
+      deliveryAddress: '',
+      deliveryContactNumber: '',
     },
   ];
 
@@ -42,6 +46,8 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'successful',
+      deliveryAddress: '',
+      deliveryContactNumber: '',
     },
   ];
 
@@ -52,6 +58,8 @@ describe('groupByCommitStatus', () => {
       listingId: 1,
       customerId: 1,
       commitStatus: 'paid',
+      deliveryAddress: '',
+      deliveryContactNumber: '',
     },
   ];
 


### PR DESCRIPTION
To be merged after #151 and #153
Part of #13 

# Changes
- Add payment flow to frontend after clicking on the "Pay" button

**Not in this PR**
- Delivery details form, currently using dummy delivery data for payment

## Screenshots
(I manually changed the `commitStatus` for the commit to be "successful" in datastore temporarily to try it out for this listing)

What happens before and after I click the Pay button:
![Screenshot 2020-07-22 at 8 49 35 PM](https://user-images.githubusercontent.com/25261058/88178989-cb1e3200-cc5d-11ea-98f8-954b0fdc334e.png)
![Screenshot 2020-07-22 at 8 49 45 PM](https://user-images.githubusercontent.com/25261058/88179002-cd808c00-cc5d-11ea-8c52-05cd885f8bf6.png)
![Screenshot 2020-07-22 at 8 49 56 PM](https://user-images.githubusercontent.com/25261058/88179008-cfe2e600-cc5d-11ea-92c3-5a726eb38209.png)

