### PR TITLE
Change numOngoingCommits to numUsedCommits

### DIFF
--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -37,7 +37,7 @@ export interface CustomerDatastoreReponse extends Required<CustomerPayload> {
  * client side would receive.
  */
 export interface CustomerResponse extends CustomerDatastoreReponse {
-  numOngoingCommits: number;
+  numUsedCommits: number;
 }
 
 /**

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -84,10 +84,10 @@ const addCommit = async (
     );
   }
 
-  // Check that customer has not reached max num of ongoing commits
-  if (customer.numOngoingCommits >= MAX_NUM_COMMITS) {
+  // Check that customer has not used up max num of commits
+  if (customer.numUsedCommits >= MAX_NUM_COMMITS) {
     throw new Error(
-      `Customer has reached max number of ${MAX_NUM_COMMITS} ongoing commits.`
+      `Customer has reached max number of ${MAX_NUM_COMMITS} commits used.`
     );
   }
 

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -23,18 +23,32 @@ import {
 } from '../interfaces';
 import {get, getAll, add} from './datastore';
 
-const getNumOngoingCommits = async (customerId: number) => {
-  const commits: CommitResponse[] = await getAll(COMMIT_KIND, [
-    {
-      property: 'customerId',
-      value: customerId,
-    },
+/**
+ * Gets number of commits used by the specified customer.
+ * @param customerId Id of the customer
+ */
+const getNumUsedCommits = async (customerId: number) => {
+  const customerFilter = {
+    property: 'customerId',
+    value: customerId,
+  };
+
+  const ongoingCommits: CommitResponse[] = await getAll(COMMIT_KIND, [
+    customerFilter,
     {
       property: 'commitStatus',
       value: 'ongoing',
     },
   ]);
-  return commits.length;
+  const succesfulCommits: CommitResponse[] = await getAll(COMMIT_KIND, [
+    customerFilter,
+    {
+      property: 'commitStatus',
+      value: 'successful',
+    },
+  ]);
+
+  return ongoingCommits.length + succesfulCommits.length;
 };
 
 const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
@@ -42,10 +56,10 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
     CUSTOMER_KIND,
     customerId
   );
-  const numOngoingCommits = await getNumOngoingCommits(customerId);
+  const numUsedCommits = await getNumUsedCommits(customerId);
   return {
     ...customer,
-    numOngoingCommits,
+    numUsedCommits,
   };
 };
 
@@ -68,10 +82,10 @@ const getCustomerWithGpayId = async (
     return null;
   }
 
-  const numOngoingCommits = await getNumOngoingCommits(customer.id);
+  const numUsedCommits = await getNumUsedCommits(customer.id);
   return {
     ...customer,
-    numOngoingCommits,
+    numUsedCommits,
   };
 };
 

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -24,13 +24,16 @@ import {
 import {get, getAll, add} from './datastore';
 
 /**
- * Gets number of commits used by the specified customer.
- * @param customerId Id of the customer
+ * Gets number of commits used by the specified customer and
+ * returns a CustomerResponse containing numUsedCommits.
+ * @param customer Existing data of the customer from datastore
  */
-const getNumUsedCommits = async (customerId: number) => {
+const withNumUsedCommits = async (
+  customer: CustomerDatastoreReponse
+): Promise<CustomerResponse> => {
   const customerFilter = {
     property: 'customerId',
-    value: customerId,
+    value: customer.id,
   };
 
   const ongoingCommits: CommitResponse[] = await getAll(COMMIT_KIND, [
@@ -48,7 +51,12 @@ const getNumUsedCommits = async (customerId: number) => {
     },
   ]);
 
-  return ongoingCommits.length + succesfulCommits.length;
+  const numUsedCommits = ongoingCommits.length + succesfulCommits.length;
+
+  return {
+    ...customer,
+    numUsedCommits,
+  };
 };
 
 const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
@@ -56,11 +64,7 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
     CUSTOMER_KIND,
     customerId
   );
-  const numUsedCommits = await getNumUsedCommits(customerId);
-  return {
-    ...customer,
-    numUsedCommits,
-  };
+  return withNumUsedCommits(customer);
 };
 
 /**
@@ -82,11 +86,7 @@ const getCustomerWithGpayId = async (
     return null;
   }
 
-  const numUsedCommits = await getNumUsedCommits(customer.id);
-  return {
-    ...customer,
-    numUsedCommits,
-  };
+  return withNumUsedCommits(customer);
 };
 
 /**

--- a/web/src/components/common/CommitsBadge.tsx
+++ b/web/src/components/common/CommitsBadge.tsx
@@ -81,7 +81,7 @@ interface CommitsBadgeProps {
  */
 const CommitsBadge: React.FC<CommitsBadgeProps> = ({pos = 'static'}) => {
   const {customer} = useCustomerContext();
-  const numCommits = customer?.numOngoingCommits;
+  const numCommits = customer?.numUsedCommits;
 
   return (
     <CommitBadgeContainer pos={pos} visible={numCommits !== undefined}>

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -140,7 +140,7 @@ export interface CustomerPayload {
  */
 export interface Customer extends Required<CustomerPayload> {
   id: number;
-  numOngoingCommits: number;
+  numUsedCommits: number;
 }
 
 /**


### PR DESCRIPTION
# Changes
- `numOngoingCommits` is changed to `numUsedCommits`(num ongoing + num successful) because customers are not given back their commits UNTIL they have paid for their commits. 
- Refactored `getNumUsedCommits` to `withNumUsedCommits` which gets the `numUsedCommits` and also does the adding of `numUsedCommits` to the passed in customer data 