### PR TITLE
Refactor datastore to use HOF transaction

### DIFF
--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -103,7 +103,11 @@ const editCommit = async (
 
   await makeTransaction(
     updateEntityInTransaction(COMMIT_KIND, commitId, commitEditRules),
-    updateEntityInTransaction(LISTING_KIND, affectedListingId, listingUpdateRules)
+    updateEntityInTransaction(
+      LISTING_KIND,
+      affectedListingId,
+      listingUpdateRules
+    )
   );
   return getCommit(commitId);
 };

--- a/server/src/storage/commits.ts
+++ b/server/src/storage/commits.ts
@@ -25,9 +25,9 @@ import {
   getEntity,
   getAllEntities,
   makeTransaction,
-  deleteInTransaction,
-  updateInTransaction,
-  addInTransaction,
+  deleteEntityInTransaction,
+  updateEntityInTransaction,
+  addEntityInTransaction,
 } from './datastore';
 import {UpdateRule} from './interfaces';
 
@@ -59,8 +59,8 @@ const addCommit = async (
   uniqueProperties?: Filter[]
 ): Promise<CommitResponse> => {
   const [commitId] = await makeTransaction(
-    addInTransaction(COMMIT_KIND, commit, uniqueProperties),
-    updateInTransaction(LISTING_KIND, commit.listingId, [
+    addEntityInTransaction(COMMIT_KIND, commit, uniqueProperties),
+    updateEntityInTransaction(LISTING_KIND, commit.listingId, [
       {
         property: 'numCommits',
         op: 'add',
@@ -102,8 +102,8 @@ const editCommit = async (
   }
 
   await makeTransaction(
-    updateInTransaction(COMMIT_KIND, commitId, commitEditRules),
-    updateInTransaction(LISTING_KIND, affectedListingId, listingUpdateRules)
+    updateEntityInTransaction(COMMIT_KIND, commitId, commitEditRules),
+    updateEntityInTransaction(LISTING_KIND, affectedListingId, listingUpdateRules)
   );
   return getCommit(commitId);
 };
@@ -116,8 +116,8 @@ const editCommit = async (
  */
 const deleteCommit = async (commitId: number, listingId: number) =>
   await makeTransaction(
-    deleteInTransaction(COMMIT_KIND, commitId),
-    updateInTransaction(LISTING_KIND, listingId, [
+    deleteEntityInTransaction(COMMIT_KIND, commitId),
+    updateEntityInTransaction(LISTING_KIND, listingId, [
       {
         property: 'numCommits',
         op: 'subtract',

--- a/server/src/storage/customers.ts
+++ b/server/src/storage/customers.ts
@@ -21,7 +21,7 @@ import {
   CustomerPayload,
   CustomerDatastoreReponse,
 } from '../interfaces';
-import {get, getAll, add} from './datastore';
+import {getEntity, getAllEntities, addEntity} from './datastore';
 
 /**
  * Gets number of commits used by the specified customer and
@@ -36,14 +36,14 @@ const withNumUsedCommits = async (
     value: customer.id,
   };
 
-  const ongoingCommits: CommitResponse[] = await getAll(COMMIT_KIND, [
+  const ongoingCommits: CommitResponse[] = await getAllEntities(COMMIT_KIND, [
     customerFilter,
     {
       property: 'commitStatus',
       value: 'ongoing',
     },
   ]);
-  const succesfulCommits: CommitResponse[] = await getAll(COMMIT_KIND, [
+  const succesfulCommits: CommitResponse[] = await getAllEntities(COMMIT_KIND, [
     customerFilter,
     {
       property: 'commitStatus',
@@ -60,7 +60,7 @@ const withNumUsedCommits = async (
 };
 
 const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
-  const customer: CustomerDatastoreReponse = await get(
+  const customer: CustomerDatastoreReponse = await getEntity(
     CUSTOMER_KIND,
     customerId
   );
@@ -76,12 +76,15 @@ const getCustomer = async (customerId: number): Promise<CustomerResponse> => {
 const getCustomerWithGpayId = async (
   gpayId: string
 ): Promise<CustomerResponse | null> => {
-  const [customer]: CustomerDatastoreReponse[] = await getAll(CUSTOMER_KIND, [
-    {
-      property: 'gpayId',
-      value: gpayId,
-    },
-  ]);
+  const [customer]: CustomerDatastoreReponse[] = await getAllEntities(
+    CUSTOMER_KIND,
+    [
+      {
+        property: 'gpayId',
+        value: gpayId,
+      },
+    ]
+  );
   if (customer === undefined) {
     return null;
   }
@@ -98,7 +101,7 @@ const getCustomerWithGpayId = async (
 const addCustomer = async (
   customer: CustomerPayload
 ): Promise<CustomerResponse> => {
-  const customerId = await add(CUSTOMER_KIND, customer, [
+  const customerId = await addEntity(CUSTOMER_KIND, customer, [
     {
       property: 'gpayId',
       value: customer.gpayId,

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -77,11 +77,10 @@ const extractAndAppendId = (res: Entity) => {
 
 /**
  * A Datastore wrapper that gets a particular entity with the specified Kind and id.
- * If actor is not specified, gets using datastore.
+ * If transaction is not specified, gets using datastore.
  * @param kind The Kind that is being retrieved
  * @param id The id of the Entity being retrieved
- * @param transaction Transaction that will carry out the retrieval,
- * if not specified, datastore will carry out the operation
+ * @param transaction Transaction that will carry out the retrieval
  */
 export const getEntity = async (
   kind: string,
@@ -113,14 +112,13 @@ export const getEntityInTransaction = async (kind: string, id: number) => (
 
 /**
  * A Datastore wrapper that gets all entities of a specified Kind.
- * If actor is not specified, gets using datastore.
+ * If transaction is not specified, gets using datastore.
  * @param kind The Kind that is being queried
  * @param filters Any filters that will be applied to the query
  * @param orderRules Any order rules that will be used to sort the query result.
  * If an orderRule doesn't have a descending property specified, the default
  * direction is ascending.
- * @param transaction Transaction that will carry out the query,
- * if not specified, datastore will carry out the operation
+ * @param transaction Transaction that will carry out the query
  */
 export const getAllEntities = async (
   kind: string,
@@ -215,12 +213,11 @@ const insertUniqueEntity = async (
  * a function that resolves to the id of the inserted entity.
  * If uniqueProperties are specified, the entity would not be added if another entity with the
  * same value for the unique properties already exists.
- * If actor is not specified, adds using datastore.
+ * If transaction is not specified, adds using datastore.
  * @param kind The Kind of the Entity to be added
  * @param data The data of the Entity to be added
  * @param uniqueProperties The properties that should be unique for the specified kind
- * @param transaction Transaction that will carry out the adding,
- * if not specified, datastore will carry out the operation
+ * @param transaction Transaction that will carry out the adding
  */
 const addEntityHelper = async (
   kind: string,
@@ -252,7 +249,6 @@ const addEntityHelper = async (
  * the id of the inserted entity.
  * If uniqueProperties are specified, the entity would not be added if another entity with the
  * same value for the unique properties already exists.
- * If actor is not specified, adds using datastore.
  * @param kind The Kind of the Entity to be added
  * @param data The data of the Entity to be added
  * @param uniqueProperties The properties that should be unique for the specified kind
@@ -307,12 +303,11 @@ const updateData = (original: StringKeyObject, updateRule: UpdateRule) => {
 /**
  * A Datastore wrapper that updates an entity with the specified kind and id
  * according to the update rules.
- * If actor is not specified, updates using datastore.
+ * If transaction is not specified, updates using datastore.
  * @param kind Kind of the entity to be updated
  * @param id id of the entity to be updated
  * @param updateRules Rules to update the entity
- * @param transaction Transaction that will carry out the update,
- * if not specified, datastore will carry out the operation
+ * @param transaction Transaction that will carry out the update
  */
 export const updateEntity = async (
   kind: string,
@@ -355,11 +350,10 @@ export const updateInTransaction = (
 
 /**
  * A Datastore wrapper that deletes an entity with the specified id.
- * If actor is not specified, deletes using datastore.
+ * If transaction is not specified, deletes using datastore.
  * @param kind Kind of the entity to be deleted
  * @param id Id of the entity to be deleted
- * @param transaction Transaction that will carry out the deletion,
- * if not specified, datastore will carry out the operation
+ * @param transaction Transaction that will carry out the deletion
  */
 export const deleteEntity = async (
   kind: string,

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -221,7 +221,7 @@ const addEntityHelper = async (
   actor: Transaction | Datastore = datastore
 ): Promise<() => number> => {
   const key = datastore.key(kind);
-  const entity = { key, data };
+  const entity = {key, data};
 
   try {
     if (uniqueProperties === undefined) {
@@ -250,7 +250,7 @@ const addEntityHelper = async (
 export const addEntity = async (
   kind: string,
   data: object,
-  uniqueProperties?: Filter[],
+  uniqueProperties?: Filter[]
 ): Promise<number> => (await addEntityHelper(kind, data, uniqueProperties))();
 
 /**

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -30,6 +30,8 @@ type TransactionOperation = (
 /**
  * A higher order function that creates a transaction and carries out all
  * input datastore operations in the same transaction.
+ * Returns the response of each operation carried out in the transaction in
+ * an array, in the same order they are called.
  * @param opFns Operations to be carried out in the same transaction
  */
 export const makeTransaction = async (

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -227,7 +227,7 @@ export const addEntity = async (
       await uniqueInsertInTransaction(kind, entity, uniqueProperties)(actor);
     }
   } catch (err) {
-    throw new Error(`Failed to add ${key}. ${err.message}`);
+    throw new Error(`Failed to add ${kind}. ${err.message}`);
   }
   return Number(key.id);
 };
@@ -300,7 +300,7 @@ export const updateEntity = async (
     };
     actor.update(entity);
   } catch (err) {
-    throw new Error(`Failed to update ${key}. ${err.message}`);
+    throw new Error(`Failed to update ${kind} ${id}. ${err.message}`);
   }
 };
 
@@ -336,7 +336,7 @@ export const deleteEntity = async (
   try {
     actor.delete(key);
   } catch (err) {
-    throw new Error(`Failed to delete ${key}. ${err.message}`);
+    throw new Error(`Failed to delete ${kind} ${id}. ${err.message}`);
   }
 };
 

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -156,7 +156,8 @@ export const getAllEntitiesInTransaction = async (
   kind: string,
   filters?: Filter[],
   orderRules?: OrderRule[]
-) => (transaction: Transaction) => getAllEntities(kind, filters, orderRules, transaction);
+) => (transaction: Transaction) =>
+  getAllEntities(kind, filters, orderRules, transaction);
 
 /**
  * A higher order function.

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -80,13 +80,16 @@ const extractAndAppendId = (res: Entity) => {
  * If actor is not specified, gets using datastore.
  * @param kind The Kind that is being retrieved
  * @param id The id of the Entity being retrieved
- * @param actor Datastore or Transaction that will carry out the retrieval
+ * @param transaction Transaction that will carry out the retrieval,
+ * if not specified, datastore will carry out the operation
  */
 export const getEntity = async (
   kind: string,
   id: number,
-  actor: Transaction | Datastore = datastore
+  transaction?: Transaction
 ) => {
+  const actor = transaction || datastore;
+
   const key = datastore.key([kind, id]);
 
   try {
@@ -116,14 +119,17 @@ export const getEntityInTransaction = async (kind: string, id: number) => (
  * @param orderRules Any order rules that will be used to sort the query result.
  * If an orderRule doesn't have a descending property specified, the default
  * direction is ascending.
- * @param actor Datastore or Transaction that will carry out the query
+ * @param transaction Transaction that will carry out the query,
+ * if not specified, datastore will carry out the operation
  */
 export const getAllEntities = async (
   kind: string,
   filters?: Filter[],
   orderRules?: OrderRule[],
-  actor: Transaction | Datastore = datastore
+  transaction?: Transaction
 ) => {
+  const actor = transaction || datastore;
+
   try {
     let query = actor.createQuery(kind);
     filters?.forEach(filter => {
@@ -213,14 +219,17 @@ const insertUniqueEntity = async (
  * @param kind The Kind of the Entity to be added
  * @param data The data of the Entity to be added
  * @param uniqueProperties The properties that should be unique for the specified kind
- * @param actor Datastore or Transaction that will carry out the adding
+ * @param transaction Transaction that will carry out the adding,
+ * if not specified, datastore will carry out the operation
  */
 const addEntityHelper = async (
   kind: string,
   data: object,
   uniqueProperties?: Filter[],
-  actor: Transaction | Datastore = datastore
+  transaction?: Transaction
 ): Promise<() => number> => {
+  const actor = transaction || datastore;
+
   const key = datastore.key(kind);
   const entity = {key, data};
 
@@ -302,14 +311,17 @@ const updateData = (original: StringKeyObject, updateRule: UpdateRule) => {
  * @param kind Kind of the entity to be updated
  * @param id id of the entity to be updated
  * @param updateRules Rules to update the entity
- * @param actor Datastore or Transaction that will carry out the update
+ * @param transaction Transaction that will carry out the update,
+ * if not specified, datastore will carry out the operation
  */
 export const updateEntity = async (
   kind: string,
   id: number,
   updateRules: UpdateRule[],
-  actor: Transaction | Datastore = datastore
+  transaction?: Transaction
 ) => {
+  const actor = transaction || datastore;
+
   const key = datastore.key([kind, id]);
 
   try {
@@ -346,13 +358,16 @@ export const updateInTransaction = (
  * If actor is not specified, deletes using datastore.
  * @param kind Kind of the entity to be deleted
  * @param id Id of the entity to be deleted
- * @param actor Datastore or Transaction that will carry out the deletion
+ * @param transaction Transaction that will carry out the deletion,
+ * if not specified, datastore will carry out the operation
  */
 export const deleteEntity = async (
   kind: string,
   id: number,
-  actor: Transaction | Datastore = datastore
+  transaction?: Transaction
 ) => {
+  const actor = transaction || datastore;
+
   const key = datastore.key([kind, id]);
 
   try {

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -33,10 +33,11 @@ type TransactionOperation = (
  * input datastore operations in the same transaction.
  * Returns the response of each operation carried out in the transaction in
  * an array, in the same order they are called.
- * @param opFns Operations to be carried out in the same transaction
+ * Throws an error and rollsback the transaction if any of the operation fails.
+ * @param operations Operations to be carried out in the same transaction
  */
 export const makeTransaction = async (
-  ...opFns: TransactionOperation[]
+  ...operations: TransactionOperation[]
 ): Promise<ResolvedResponse[]> => {
   const transaction = datastore.transaction();
 
@@ -45,8 +46,8 @@ export const makeTransaction = async (
   try {
     await transaction.run();
 
-    for (const fn of opFns) {
-      resArr.push(await fn(transaction));
+    for (const operation of operations) {
+      resArr.push(await operation(transaction));
     }
 
     await transaction.commit();

--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -267,7 +267,7 @@ export const addEntity = async (
  * @param data The data of the Entity to be added
  * @param uniqueProperties The properties that should be unique for the specified kind
  */
-export const addInTransaction = (
+export const addEntityInTransaction = (
   kind: string,
   data: object,
   uniqueProperties?: Filter[]
@@ -341,7 +341,7 @@ export const updateEntity = async (
  * @param id id of the entity to be updated
  * @param updateRules Rules to update the entity
  */
-export const updateInTransaction = (
+export const updateEntityInTransaction = (
   kind: string,
   id: number,
   updateRules: UpdateRule[]
@@ -378,6 +378,6 @@ export const deleteEntity = async (
  * @param kind Kind of the entity to be deleted
  * @param id Id of the entity to be deleted
  */
-export const deleteInTransaction = (kind: string, id: number) => async (
+export const deleteEntityInTransaction = (kind: string, id: number) => async (
   transaction: Transaction
 ) => deleteEntity(kind, id, transaction);

--- a/server/src/storage/listings.ts
+++ b/server/src/storage/listings.ts
@@ -33,7 +33,8 @@ const defaultOrderRule = {
 const getAllListings = async (
   filters?: Filter[],
   orderRules: OrderRule[] = [defaultOrderRule]
-): Promise<ListingResponse[]> => getAllEntities(LISTING_KIND, filters, orderRules);
+): Promise<ListingResponse[]> =>
+  getAllEntities(LISTING_KIND, filters, orderRules);
 
 const getListing = async (listingId: number): Promise<ListingResponse> =>
   getEntity(LISTING_KIND, listingId);

--- a/server/src/storage/listings.ts
+++ b/server/src/storage/listings.ts
@@ -17,12 +17,12 @@
 import {Filter, ListingPayload, ListingResponse, OrderRule} from 'interfaces';
 
 import {LISTING_KIND} from '../constants/kinds';
-import {add, getAll, get} from './datastore';
+import {addEntity, getAllEntities, getEntity} from './datastore';
 
 const addListing = async (
   listing: ListingPayload
 ): Promise<ListingResponse> => {
-  const listingId = await add(LISTING_KIND, listing);
+  const listingId = await addEntity(LISTING_KIND, listing);
   return getListing(listingId);
 };
 
@@ -33,9 +33,9 @@ const defaultOrderRule = {
 const getAllListings = async (
   filters?: Filter[],
   orderRules: OrderRule[] = [defaultOrderRule]
-): Promise<ListingResponse[]> => getAll(LISTING_KIND, filters, orderRules);
+): Promise<ListingResponse[]> => getAllEntities(LISTING_KIND, filters, orderRules);
 
 const getListing = async (listingId: number): Promise<ListingResponse> =>
-  get(LISTING_KIND, listingId);
+  getEntity(LISTING_KIND, listingId);
 
 export default {addListing, getAllListings, getListing};

--- a/server/src/storage/merchants.ts
+++ b/server/src/storage/merchants.ts
@@ -21,14 +21,14 @@
 
 import {MERCHANT_KIND} from '../constants/kinds';
 import {Filter, MerchantPayload, MerchantResponse} from '../interfaces';
-import {add, get, getAll} from './datastore';
+import {addEntity, getEntity, getAllEntities} from './datastore';
 
 const getMerchant = async (merchantId: number): Promise<MerchantResponse> =>
-  get(MERCHANT_KIND, merchantId);
+  getEntity(MERCHANT_KIND, merchantId);
 
 const getAllMerchants = async (
   filters?: Filter[]
-): Promise<MerchantResponse[]> => getAll(MERCHANT_KIND, filters);
+): Promise<MerchantResponse[]> => getAllEntities(MERCHANT_KIND, filters);
 
 const addMerchant = async (
   merchant: MerchantPayload
@@ -37,7 +37,9 @@ const addMerchant = async (
     property: 'firebaseUid',
     value: merchant.firebaseUid,
   };
-  const merchantId = await add(MERCHANT_KIND, merchant, [uniqueFirebaseUid]);
+  const merchantId = await addEntity(MERCHANT_KIND, merchant, [
+    uniqueFirebaseUid,
+  ]);
   return getMerchant(merchantId);
 };
 


### PR DESCRIPTION
Closes #161
**Please refer to #161 for background for this PR**

# Changes
- Added higher order function `makeTransaction` in datastore layer
- Added "building blocks" for transactions, such as `getEntityInTransaction` and other functions ending with `InTransaction` 
- Replaced all existing transaction functions like `addAndUpdateRelatedEntity` with `makeTransaction` and the appropriate "building blocks". 

So now, instead of
```
  const commitId = await addAndUpdateRelatedEntity(
    COMMIT_KIND,
    commit,
    LISTING_KIND,
    commit.listingId,
    [
      {
        property: 'numCommits',
        op: 'add',
        value: 1,
      },
    ],
    uniqueProperties
  );
```
We now do
```
  const [commitId] = await makeTransaction(
    addInTransaction(COMMIT_KIND, commit, uniqueProperties),
    updateInTransaction(LISTING_KIND, commit.listingId, [
      {
        property: 'numCommits',
        op: 'add',
        value: 1,
      },
    ])
  );
```

# Testing
**Successful GET for listings (shows that non-transaction operations works)**
![Screenshot 2020-07-28 at 7 53 44 PM](https://user-images.githubusercontent.com/25261058/88663505-4ecc9880-d10e-11ea-942f-2b2d57b9c2b4.png)

**Successful DELETE for commits, and the updating of `numCommits` in Listing (shows that transaction works)**
![image](https://user-images.githubusercontent.com/25261058/88663875-d2868500-d10e-11ea-8d2a-bd2f880c5ea8.png)
![image](https://user-images.githubusercontent.com/25261058/88663904-dc0fed00-d10e-11ea-99f1-ce9199ad815f.png)

**Successful POST for commits, and the updating of `numCommits` in Listing (shows that transaction works)**
![Screenshot 2020-07-28 at 8 54 33 PM](https://user-images.githubusercontent.com/25261058/88675337-6cedc500-d11d-11ea-97b7-a619aa6e3c11.png)
![image](https://user-images.githubusercontent.com/25261058/88675627-afaf9d00-d11d-11ea-9a1f-a92e65472e62.png)

**Failed POST for commits (shows that failing in transaction works)**
![Screenshot 2020-07-28 at 8 03 19 PM](https://user-images.githubusercontent.com/25261058/88663508-50965c00-d10e-11ea-9e4b-42c1ac6207f9.png)


