### PR TITLE
Modify package.json scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
       before_install:
         - cd web
       script:
+        - yarn typecheck
         - yarn lint
         - yarn test
         - yarn build

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,6 @@
     "compile": "tsc",
     "prepare": "yarn run compile",
     "pretest": "yarn run compile",
-    "posttest": "",
     "test": "$(gcloud beta emulators datastore env-init) && cross-env NODE_ENV=test jest --forceExit",
     "test:watch": "yarn test --watch",
     "test:emulator": "gcloud beta emulators datastore start --no-store-on-disk --host-port=localhost:8081"

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "compile": "tsc",
     "prepare": "yarn run compile",
     "pretest": "yarn run compile",
-    "posttest": "yarn run lint",
+    "posttest": "",
     "test": "$(gcloud beta emulators datastore env-init) && cross-env NODE_ENV=test jest --forceExit",
     "test:watch": "yarn test --watch",
     "test:emulator": "gcloud beta emulators datastore start --no-store-on-disk --host-port=localhost:8081"

--- a/web/README.md
+++ b/web/README.md
@@ -38,9 +38,9 @@ Automatically fixes formatting and linting problems (if possible) according to [
 
 Removes output files.
 
-### `yarn compile`
+### `yarn typecheck`
 
-Compiles the source code using TypeScript compiler.
+Runs typechecking with the TypeScript compiler without emitting JS files.
 
 ### `yarn test`
 

--- a/web/package.json
+++ b/web/package.json
@@ -45,7 +45,7 @@
     "fix": "gts fix",
     "prepare": "yarn compile",
     "pretest": "yarn compile",
-    "posttest": "yarn lint"
+    "posttest": ""
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/web/package.json
+++ b/web/package.json
@@ -41,10 +41,10 @@
     "lint:code": "gts check",
     "lint:css": "stylelint ./src/**/*.tsx",
     "clean": "gts clean",
-    "compile": "tsc",
+    "typecheck": "tsc",
     "fix": "gts fix",
-    "prepare": "yarn compile",
-    "pretest": "yarn compile",
+    "prepare": "yarn typecheck",
+    "pretest": "yarn typecheck",
     "posttest": ""
   },
   "eslintConfig": {

--- a/web/package.json
+++ b/web/package.json
@@ -44,8 +44,7 @@
     "typecheck": "tsc",
     "fix": "gts fix",
     "prepare": "yarn typecheck",
-    "pretest": "yarn typecheck",
-    "posttest": ""
+    "pretest": "yarn typecheck"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
# Changes
- Removed running of linter in posttest script
  * Running `yarn test` shall only run tests instead of doing both testing and linting.
  * In our [travis script](https://github.com/googleinterns/gpay-group-buy/blob/master/.travis.yml#L25), we run `yarn lint` before running `yarn test`. This is because we would like to feedback lint failures to the user asap. 
Keeping the posstest linting results in checking for linting twice in the travis script, which is unnecessary. 
- Renamed `compile` script on client side to `typecheck` instead. Our client side uses Babel to compile instead of the typescript compiler. Running `tsc` on the frontend will not emit compiled files because of the `noEmit` compiler option [here](https://github.com/googleinterns/gpay-group-buy/blob/9d917e4ba9dd1e4391624900d143239f8f567bea/web/tsconfig.json#L20). Hence doing `tsc` only does typechecking and "compile" does not seem like the right word.