### PR TITLE
Remove dead code from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 dist: xenial
-apt:
-  packages:
-    - google-cloud-sdk
 language: node_js
 node_js: 10
 cache: yarn


### PR DESCRIPTION
# Changes
- This piece of code that I am removing is left behind previously when I was trying out on the installation of google cloud sdk on travis. The actual working installation is done on lines 10-16. Removing this because I just realised I forgot to remove it previously! :( 