### PR TITLE
Add listing card with commit status

### DIFF
--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -20,7 +20,7 @@ import CardImage from 'components/common/CardImage';
 import {Image} from 'interfaces';
 import styled from 'styled-components';
 
-const DEFAULT_IMG_WIDTH = '150px';
+const DEFAULT_IMG_WIDTH = '116px';
 
 interface CardContainerProps {
   horizontal?: boolean;

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -21,11 +21,43 @@ import DeadlineTag from 'components/common/DeadlineTag';
 import LazyWrapper from 'components/common/LazyWrapper';
 import ListingPrice from 'components/common/ListingPrice';
 import {Money} from 'interfaces';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
+
+type ChildrenPos = 'bottom' | 'right';
 
 const CardContent = styled.div`
   display: flex;
   flex-direction: column;
+`;
+
+interface DetailsProps {
+  childrenPos?: ChildrenPos;
+}
+
+const detailsColStyle = css`
+  flex-direction: column;
+`;
+
+const detailsRowStyle = css`
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Details = styled.div`
+  display: flex;
+
+  /* stylelint-disable value-keyword-case */
+  ${({childrenPos}: DetailsProps) => {
+    switch (childrenPos) {
+      case 'right':
+        return detailsRowStyle;
+      case 'bottom':
+      default:
+        return detailsColStyle;
+    }
+  }};
+  /* stylelint-enable value-keyword-case */
 `;
 
 const ListingName = styled.span`
@@ -41,6 +73,7 @@ interface ListingCardProps {
   endDate: string;
   imgUrl: string;
   horizontal?: boolean;
+  childrenPos?: ChildrenPos;
 }
 
 /**
@@ -54,6 +87,7 @@ const ListingCard: React.FC<ListingCardProps> = ({
   imgUrl,
   endDate,
   horizontal,
+  childrenPos = 'bottom',
   children,
 }) => (
   <LazyWrapper>
@@ -66,9 +100,13 @@ const ListingCard: React.FC<ListingCardProps> = ({
     >
       <CardContent>
         <DeadlineTag deadline={endDate} />
-        <ListingName>{listingName}</ListingName>
-        <ListingPrice price={price} oldPrice={oldPrice} />
-        {children}
+        <Details childrenPos={childrenPos}>
+          <div>
+            <ListingName>{listingName}</ListingName>
+            <ListingPrice price={price} oldPrice={oldPrice} />
+          </div>
+          <div>{children}</div>
+        </Details>
       </CardContent>
     </Card>
   </LazyWrapper>

--- a/web/src/components/customer/my-commits/CommitStatusBadge.tsx
+++ b/web/src/components/customer/my-commits/CommitStatusBadge.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {CommitStatus} from 'interfaces';
+import styled, {css} from 'styled-components';
+
+const dangerStyle = css`
+  background-color: var(--bright-red);
+  color: white;
+`;
+
+const successStyle = css`
+  background-color: var(--pale-green);
+  color: var(--green);
+`;
+
+const grayedStyle = css`
+  background-color: var(--pale-gray);
+  color: var(--gray);
+`;
+
+const BadgeContainer = styled.div`
+  min-width: 3em;
+  max-width: fit-content;
+  padding: 0.5em 1em;
+  border-radius: 15px;
+
+  text-transform: uppercase;
+  font-weight: bold;
+  text-align: center;
+  font-size: 0.9em;
+  letter-spacing: 0.5px;
+
+  ${({commitStatus}: CommitStatusBadgeProps) => {
+    switch (commitStatus) {
+      case 'successful':
+        return dangerStyle;
+      case 'paid':
+      case 'completed':
+        return successStyle;
+      case 'unsuccessful':
+        return grayedStyle;
+      case 'ongoing':
+      default:
+        return '';
+    }
+  }}
+`;
+
+const getBadgeText = (commitStatus: CommitStatus) => {
+  switch (commitStatus) {
+    case 'successful':
+      return 'Pay';
+    case 'paid':
+      return 'Waiting Delivery';
+    case 'completed':
+      return 'Delivered';
+    case 'unsuccessful':
+      return 'Failed';
+    case 'ongoing':
+    default:
+      return '';
+  }
+};
+
+interface CommitStatusBadgeProps {
+  commitStatus: CommitStatus;
+}
+
+/**
+ * CommitStatusBadge displays the specified commit status in a styled badge.
+ */
+const CommitStatusBadge: React.FC<CommitStatusBadgeProps> = ({
+  commitStatus,
+}) => (
+  <BadgeContainer commitStatus={commitStatus}>
+    {getBadgeText(commitStatus)}
+  </BadgeContainer>
+);
+
+export default CommitStatusBadge;

--- a/web/src/components/customer/my-commits/CommitStatusBadge.tsx
+++ b/web/src/components/customer/my-commits/CommitStatusBadge.tsx
@@ -46,6 +46,7 @@ const BadgeContainer = styled.div`
   font-size: 0.9em;
   letter-spacing: 0.5px;
 
+  /* stylelint-disable value-keyword-case */
   ${({commitStatus}: CommitStatusBadgeProps) => {
     switch (commitStatus) {
       case 'successful':
@@ -59,7 +60,7 @@ const BadgeContainer = styled.div`
       default:
         return '';
     }
-  }}
+  }}/* stylelint-enable value-keyword-case */
 `;
 
 const getBadgeText = (commitStatus: CommitStatus) => {

--- a/web/src/components/customer/my-commits/CommitStatusBadge.tsx
+++ b/web/src/components/customer/my-commits/CommitStatusBadge.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import {CommitStatus} from 'interfaces';
 import styled, {css} from 'styled-components';
 
-const dangerStyle = css`
+const pendingActionStyle = css`
   background-color: var(--bright-red);
   color: white;
 `;
@@ -50,7 +50,7 @@ const BadgeContainer = styled.div`
   ${({commitStatus}: CommitStatusBadgeProps) => {
     switch (commitStatus) {
       case 'successful':
-        return dangerStyle;
+        return pendingActionStyle;
       case 'paid':
       case 'completed':
         return successStyle;

--- a/web/src/components/customer/my-commits/ListingCardWithCommitStatus.tsx
+++ b/web/src/components/customer/my-commits/ListingCardWithCommitStatus.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import ListingCard from 'components/common/ListingCard';
+import StrippedCol from 'components/common/StrippedCol';
+import CommitStatusBadge from 'components/customer/my-commits/CommitStatusBadge';
+import {Listing, CommitStatus} from 'interfaces';
+import styled from 'styled-components';
+
+const CommitsContainer = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+
+  word-break: break-word;
+
+  & > h2 {
+    font-size: 1.4em;
+  }
+`;
+
+interface ListingCardProps {
+  listing: Listing;
+  commitStatus: CommitStatus;
+}
+
+/**
+ * A listing card that displays the customer's commit status of the listing.
+ */
+const ListingCardWithCommitStatus: React.FC<ListingCardProps> = ({
+  listing: {name, price, oldPrice, deadline, imgUrl},
+  commitStatus,
+}) => (
+  <StrippedCol xs={12}>
+    <ListingCard
+      listingName={name}
+      price={price}
+      oldPrice={oldPrice}
+      endDate={deadline}
+      imgUrl={imgUrl}
+      horizontal
+      childrenPos="right"
+    >
+      <CommitStatusBadge commitStatus={commitStatus} />
+    </ListingCard>
+  </StrippedCol>
+);
+
+export default ListingCardWithCommitStatus;

--- a/web/src/components/customer/my-commits/ListingCardWithCommitStatus.tsx
+++ b/web/src/components/customer/my-commits/ListingCardWithCommitStatus.tsx
@@ -20,18 +20,6 @@ import ListingCard from 'components/common/ListingCard';
 import StrippedCol from 'components/common/StrippedCol';
 import CommitStatusBadge from 'components/customer/my-commits/CommitStatusBadge';
 import {Listing, CommitStatus} from 'interfaces';
-import styled from 'styled-components';
-
-const CommitsContainer = styled.div`
-  display: flex;
-  flex-flow: column wrap;
-
-  word-break: break-word;
-
-  & > h2 {
-    font-size: 1.4em;
-  }
-`;
 
 interface ListingCardProps {
   listing: Listing;

--- a/web/src/components/design-samples/index.tsx
+++ b/web/src/components/design-samples/index.tsx
@@ -20,9 +20,10 @@ import Card from 'components/common/Card';
 import CommitProgress from 'components/common/CommitProgress';
 import ListingCard from 'components/common/ListingCard';
 import StrippedCol from 'components/common/StrippedCol';
+import ListingCardWithCommitStatus from 'components/customer/my-commits/ListingCardWithCommitStatus';
 import MobilePromptSample from 'components/design-samples/MobilePromptSample';
 import {formatRFC3339} from 'date-fns';
-import {Money} from 'interfaces';
+import {Money, Listing} from 'interfaces';
 import Container from 'muicss/lib/react/container';
 
 const SAMPLE_IMG_URL = 'https://picsum.photos/seed/picsum/200/300';
@@ -36,6 +37,21 @@ const SAMPLE_OLD_PRICE: Money = {
   currency: 'USD',
   dollars: 121,
   cents: 0,
+};
+const SAMPLE_LISTING: Listing = {
+  merchantId: 1,
+  name: 'Some Listing',
+  price: SAMPLE_PRICE,
+  oldPrice: SAMPLE_OLD_PRICE,
+  imgUrl: SAMPLE_IMG_URL,
+  description: '',
+  deadline: SAMPLE_END_DATE,
+  minCommits: 100,
+  id: 1,
+  numCommits: 0,
+  numPaid: 0,
+  numCompleted: 0,
+  listingStatus: 'ongoing',
 };
 
 const DesignSamplesPage: React.FC = () => (
@@ -77,6 +93,22 @@ const DesignSamplesPage: React.FC = () => (
           <CommitProgress numCommits={70} minCommits={100} />
         </ListingCard>
       </StrippedCol>
+      <ListingCardWithCommitStatus
+        listing={SAMPLE_LISTING}
+        commitStatus="successful"
+      />
+      <ListingCardWithCommitStatus
+        listing={SAMPLE_LISTING}
+        commitStatus="paid"
+      />
+      <ListingCardWithCommitStatus
+        listing={SAMPLE_LISTING}
+        commitStatus="completed"
+      />
+      <ListingCardWithCommitStatus
+        listing={SAMPLE_LISTING}
+        commitStatus="unsuccessful"
+      />
       <StrippedCol xs={12}>
         <Card
           img={{


### PR DESCRIPTION
Merge after #174 

# Changes
- Added `ListingCardWithCommitStatus` which displays the customer's commit status of the listing. [(UI mock](https://www.figma.com/file/x0PWXRWxwSopiixYv41mK7/GPay-GroupBuy?node-id=1%3A40239))
- Added some samples to the design-samples page

**TODO for future PRs**
- Fix Card height to follow height of content instead of height of image (see screenshots to see what I mean)
  * Not too sure when this problem happened but it happened before this PR, so I would consider it out of scope for this PR

# Screenshots
**This is how it looks like now**
![Screenshot 2020-07-29 at 4 48 19 PM](https://user-images.githubusercontent.com/25261058/88780831-20a69180-d1be-11ea-97ee-f7763fadac98.png)

**This is how it should look like after I fix the Card height bug**
![Screenshot 2020-07-29 at 4 48 02 PM](https://user-images.githubusercontent.com/25261058/88780838-22705500-d1be-11ea-97eb-9fadb11c31a7.png)

# How to test
Fetch my branch and 
```
cd web
yarn
yarn start
```
And navigate to `http://localhost:3000/design-samples`.