### PR TITLE
Fix card img height

### DIFF
--- a/web/src/components/common/CardImage.tsx
+++ b/web/src/components/common/CardImage.tsx
@@ -27,12 +27,14 @@ interface CardContainerProps {
 }
 
 const ImageContainer = styled.div`
+  position: relative;
   width: ${({width}: CardContainerProps) => width || '100%'};
   min-height: ${MIN_IMG_HEIGHT};
   height: ${({height}: CardContainerProps) => height || MIN_IMG_HEIGHT};
 `;
 
 const StyledCardImage = styled.img`
+  position: absolute;
   width: inherit;
   height: inherit;
   object-fit: cover;


### PR DESCRIPTION
Merge after #176 

# Changes
- Fixed card image height. Now card height follows height of content (with min height of 120px), instead of following the height of the image.

![image](https://user-images.githubusercontent.com/25261058/88789263-1e960000-d1c9-11ea-8a68-bdd0b142f2ee.png)

# How to test
Fetch my branch and 
```
cd web
yarn
yarn start
```
And navigate to `http://localhost:3000/design-samples`.