### PR TITLE
Add listing cards to My Commits page

### DIFF
--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -42,6 +42,18 @@ const detailsRowStyle = css`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+
+  & > div {
+    margin-left: 5px;
+
+    :first-child {
+      margin-left: 0px;
+    }
+  }
+`;
+
+const ChildrenContainer = styled.div`
+  flex: 1;
 `;
 
 const Details = styled.div`
@@ -105,7 +117,7 @@ const ListingCard: React.FC<ListingCardProps> = ({
             <ListingName>{listingName}</ListingName>
             <ListingPrice price={price} oldPrice={oldPrice} />
           </div>
-          <div>{children}</div>
+          <ChildrenContainer>{children}</ChildrenContainer>
         </Details>
       </CardContent>
     </Card>

--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -47,7 +47,7 @@ const detailsRowStyle = css`
     margin-left: 5px;
 
     :first-child {
-      margin-left: 0px;
+      margin-left: 0;
     }
   }
 `;

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -21,6 +21,7 @@ import {Commit, GroupedCommits, Listing} from 'interfaces';
 import styled from 'styled-components';
 
 import ListingCardWithCommitStatus from './ListingCardWithCommitStatus';
+import { Link } from 'react-router-dom';
 
 const CommitsContainer = styled.div`
   display: flex;
@@ -52,11 +53,20 @@ const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
   return (
     <>
       {listings.map((listing, idx) => (
-        <ListingCardWithCommitStatus
-          key={idx}
-          listing={listing}
-          commitStatus={commits[idx].commitStatus}
-        />
+        <Link
+          to={{
+            pathname: `listing/${listing.id}`,
+            state: {
+              fromExplore: true,
+            },
+          }}
+        >
+          <ListingCardWithCommitStatus
+            key={idx}
+            listing={listing}
+            commitStatus={commits[idx].commitStatus}
+          />
+        </Link>
       ))}
     </>
   );

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -57,7 +57,7 @@ const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
           to={{
             pathname: `listing/${listing.id}`,
             state: {
-              fromExplore: true,
+              hasBack: true,
             },
           }}
           key={idx}

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -17,11 +17,10 @@
 import React, {useState, useEffect} from 'react';
 
 import {getAllListings} from 'api';
+import ListingCardWithCommitStatus from 'components/customer/my-commits/ListingCardWithCommitStatus';
 import {Commit, GroupedCommits, Listing} from 'interfaces';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
-
-import ListingCardWithCommitStatus from './ListingCardWithCommitStatus';
 
 const CommitsContainer = styled.div`
   display: flex;

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -18,10 +18,10 @@ import React, {useState, useEffect} from 'react';
 
 import {getAllListings} from 'api';
 import {Commit, GroupedCommits, Listing} from 'interfaces';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import ListingCardWithCommitStatus from './ListingCardWithCommitStatus';
-import { Link } from 'react-router-dom';
 
 const CommitsContainer = styled.div`
   display: flex;
@@ -60,9 +60,9 @@ const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
               fromExplore: true,
             },
           }}
+          key={idx}
         >
           <ListingCardWithCommitStatus
-            key={idx}
             listing={listing}
             commitStatus={commits[idx].commitStatus}
           />

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 
-import {Commit, GroupedCommits} from 'interfaces';
+import {getAllListings} from 'api';
+import {Commit, GroupedCommits, Listing} from 'interfaces';
 import styled from 'styled-components';
+
+import ListingCardWithCommitStatus from './ListingCardWithCommitStatus';
 
 const CommitsContainer = styled.div`
   display: flex;
@@ -33,10 +36,31 @@ interface CommitSectionProps {
   commits: Commit[];
 }
 
-// TODO: Change this to show horizontal listing cards
-const CommitSection: React.FC<CommitSectionProps> = ({commits}) => (
-  <>{JSON.stringify(commits)}</>
-);
+const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
+  const [listings, setListings] = useState<Listing[]>([]);
+
+  useEffect(() => {
+    const fetchListings = async () => {
+      const listingIds = commits.map(commit => commit.listingId);
+      const listings = await getAllListings({ids: listingIds.join(',')});
+      setListings(listings);
+    };
+
+    fetchListings();
+  }, [commits]);
+
+  return (
+    <>
+      {listings.map((listing, idx) => (
+        <ListingCardWithCommitStatus
+          key={idx}
+          listing={listing}
+          commitStatus={commits[idx].commitStatus}
+        />
+      ))}
+    </>
+  );
+};
 
 interface CommitsProps {
   commits: GroupedCommits;

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -125,10 +125,18 @@ export interface Listing extends ListingPayload {
 }
 
 /**
+ * ListingQueryParams Interface that contains the possible query parameters
+ * for Listings.
+ */
+export interface ListingQueryParams extends Listing {
+  ids: string;
+}
+
+/**
  * ListingQuery Interface that contains the fields of the query that
  * would be sent to the server to query for listings.
  */
-export type ListingQuery = Partial<Listing>;
+export type ListingQuery = Partial<ListingQueryParams>;
 
 /**
  * CommitStatus type contains the different states of a Commit.


### PR DESCRIPTION
# Changes
- Added listing cards with commit status to My Commits page

**TODO for this PR:**
- [x] `fromExplore: true` in the `Link` (line 60) to be changed to `hasBack` after master is merged into the ancestor branch.
- [x] Add `ids` to ListingQuery

![Screenshot 2020-07-29 at 11 45 46 PM](https://user-images.githubusercontent.com/25261058/88873536-6cede200-d24f-11ea-9d31-9c0e2bb4ed06.png)
