### PR TITLE
Only show ongoing listings on merchant profile page

### DIFF
--- a/web/src/components/customer/merchant-profile/index.tsx
+++ b/web/src/components/customer/merchant-profile/index.tsx
@@ -89,6 +89,7 @@ const MerchantProfilePage: React.FC = () => {
     const fetchListings = async () => {
       const listings = await getAllListings({
         merchantId: merchantId,
+        listingStatus: 'ongoing',
       });
       setListings(listings);
     };


### PR DESCRIPTION
# Changes
- Added listingStatus as a query param to the listings when fetching merchant profile
  * This fixes the bug that we saw during meeting just now. Apparently, changes has been made to the backend before my PR #158 got merged which enforces that listings has to be filtered by `listingStatus` after filtering by `merchantId`.

![image](https://user-images.githubusercontent.com/25261058/88880563-a9c1d500-d25f-11ea-8f14-f6d3e2c7235f.png)
