### PR TITLE
Order explore listings by earliest deadline and only show ongoing listings

### DIFF
--- a/server/index.yaml
+++ b/server/index.yaml
@@ -18,3 +18,8 @@ indexes:
   - name: merchantId
   - name: listingStatus
   - name: deadline
+
+- kind: Listing
+  properties:
+  - name: listingStatus
+  - name: deadline

--- a/web/src/components/customer/explore/index.tsx
+++ b/web/src/components/customer/explore/index.tsx
@@ -46,7 +46,9 @@ const CustomerExplorePage: React.FC = () => {
 
   useEffect(() => {
     const fetchListings = async () => {
-      const listings = await getAllListings();
+      const listings = await getAllListings({
+        listingStatus: 'ongoing',
+      });
       setListings(listings);
     };
     fetchListings();


### PR DESCRIPTION
# Changes
- Only show ongoing listings, and order listings by earliest deadline

**Screenshot**
(The first listing still has 'ongoing' status because #93 is not implemented yet)
![image](https://user-images.githubusercontent.com/25261058/88887758-9cace200-d26f-11ea-9887-eb953fed87f7.png)
