### PR TITLE
Cache microapps idToken

### DIFF
--- a/web/src/components/customer/contexts/CustomerContext.tsx
+++ b/web/src/components/customer/contexts/CustomerContext.tsx
@@ -61,7 +61,6 @@ const CustomerProvider: React.FC = ({children}) => {
 
     const customer = await loginCustomer({gpayId}, idToken);
     setCustomer(customer);
-    return customer;
   }, []);
 
   useEffect(() => {
@@ -78,7 +77,7 @@ const CustomerProvider: React.FC = ({children}) => {
    */
   const getCustomerWithLogin = async () => {
     if (customer === undefined) {
-      return login();
+      await login();
     }
     return customer;
   };

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -15,6 +15,14 @@
  */
 
 /**
+ * CustomerIdentity object that contains the customer identity token and its decoded form.
+ */
+export interface CustomerIdentity {
+  idToken: string;
+  decodedToken: any;
+}
+
+/**
  * NonEmptyArray type enforces at least 1 element of type T in the array.
  */
 export type NonEmptyArray<T> = [T, ...T[]];


### PR DESCRIPTION
# Background
Microapps API returns a  different identity token every time we try to get identity, even when it is the same gpay user and the previous token has not expired. This resulted in unnecessary rerenders of our app that listens to change the value of `idToken` in CustomerContext. This is not ideal, and we want to use the same `idToken` if it is not yet expired.

# Changes
- Cache microapps idToken and use that idToken as long as it is not expired