### PR TITLE
Store whether customer is existing customer in localstorage

### DIFF
--- a/web/src/components/common/hooks/useLocalStorage.ts
+++ b/web/src/components/common/hooks/useLocalStorage.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {useState, useCallback} from 'react';
+
+/**
+ * Code referenced from: https://usehooks.com/useLocalStorage/
+ * useLocalStorage hook that syncs state to local storage so it persists through
+ * a page refresh.
+ * @param key Local storage key
+ * @param initialValue Default value if key does not exist in local storage
+ */
+const useLocalStorage = <T>(
+  key: string,
+  initialValue: T
+): [T, (currValue: T) => void] => {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  /**
+   * Sets stored value to a value, or perform an operation on the currently stored value.
+   * @param value New value to be stored, or a function to perform an operation
+   * on the currently stored value
+   */
+  const setValue = useCallback(
+    (value: T | ((currValue: T) => T)) => {
+      try {
+        const valueToStore =
+          value instanceof Function ? value(storedValue) : value;
+        setStoredValue(valueToStore);
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [storedValue, key]
+  );
+
+  return [storedValue, setValue];
+};
+
+export default useLocalStorage;

--- a/web/src/components/customer/contexts/CustomerContext.tsx
+++ b/web/src/components/customer/contexts/CustomerContext.tsx
@@ -17,6 +17,7 @@
 import React, {useContext, useState, useEffect, useCallback} from 'react';
 
 import {getCustomer as fetchCustomer, loginCustomer} from 'api';
+import useLocalStorage from 'components/common/hooks/useLocalStorage';
 import {Customer} from 'interfaces';
 import {getIdentity} from 'microapps';
 
@@ -48,6 +49,11 @@ const useCustomerContext = () => {
  * CustomerProvider provider with stateful customer info.
  */
 const CustomerProvider: React.FC = ({children}) => {
+  const [isExistingCustomer, setIsExistingCustomer] = useLocalStorage<boolean>(
+    'isExistingCustomer',
+    false
+  );
+
   const [idToken, setIdToken] = useState<string>();
 
   const [customer, setCustomer] = useState<Customer>();
@@ -61,13 +67,18 @@ const CustomerProvider: React.FC = ({children}) => {
 
     const customer = await loginCustomer({gpayId}, idToken);
     setCustomer(customer);
-  }, []);
+    setIsExistingCustomer(true);
+  }, [setIsExistingCustomer]);
+
+  useEffect(() => {
+    if (isExistingCustomer) {
+      login();
+    }
+  }, [isExistingCustomer, login]);
 
   useEffect(() => {
     if (idToken === undefined) {
       setCustomer(undefined);
-    } else {
-      login();
     }
   }, [idToken, login]);
 

--- a/web/src/components/customer/explore/index.tsx
+++ b/web/src/components/customer/explore/index.tsx
@@ -20,7 +20,6 @@ import {getAllListings} from 'api';
 import CommitsBadge from 'components/common/CommitsBadge';
 import ListingCollection from 'components/common/ListingCollection';
 import Loading from 'components/common/Loading';
-import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
 import {Listing} from 'interfaces';
 import Button from 'muicss/lib/react/button';
 import Container from 'muicss/lib/react/container';
@@ -29,6 +28,7 @@ import styled from 'styled-components';
 
 const PageContainer = styled(Container)`
   padding-top: 20px;
+  padding-bottom: 20px;
 
   display: flex;
   flex-direction: column;
@@ -39,10 +39,6 @@ const CommitsBadgeContainer = styled.div`
 `;
 
 const CustomerExplorePage: React.FC = () => {
-  const {getCustomerWithLogin} = useCustomerContext();
-
-  const handleGetIdentity = async () => getCustomerWithLogin();
-
   const [isListingsLoading, setIsListingsLoading] = useState(true);
   const [listings, setListings] = useState<Listing[]>([]);
 
@@ -73,9 +69,6 @@ const CustomerExplorePage: React.FC = () => {
       ) : (
         <ListingCollection listings={listings} />
       )}
-      <Button color="primary" onClick={handleGetIdentity}>
-        Get Identity
-      </Button>
     </PageContainer>
   );
 };


### PR DESCRIPTION
Closes #186
**Please read #186 for background of this PR**

# Changes
- Added `isExistingCustomer` flag to localstorage so that we can identity if it is an existing customer
  * If existing customer, CustomerContext will log in customer when they enter the app
  * else, do nothing, retain original behaviour
- Added `useLocalStorageHook` that handles setting and getting of state to persist in localstorage
- Removed "Get Identity" button on Explore page because we don't need it anymore :) 

This is how localstorage looks like after I tried logging in once (retains after page refreshes)
![Screenshot 2020-08-03 at 6 43 22 PM](https://user-images.githubusercontent.com/25261058/89176925-03f2cb00-d5bd-11ea-921b-5964b3bdb9cc.png)
