### PR TITLE
Directly lead customers to payment flow from My Commits "Pay" button

### DIFF
--- a/web/src/components/customer/listing-details/ActionBar.tsx
+++ b/web/src/components/customer/listing-details/ActionBar.tsx
@@ -18,10 +18,12 @@ import React, {useState, useEffect, useCallback} from 'react';
 
 import {useCommitContext} from 'components/customer/listing-details/contexts/CommitContext';
 import {useFulfilmentDetailsPromptContext} from 'components/customer/listing-details/contexts/FulfilmentDetailsPromptContext';
+import {ListingLocation} from 'components/customer/listing-details/interfaces';
 import {CommitStatus} from 'interfaces';
 import Button from 'muicss/lib/react/button';
 import Container from 'muicss/lib/react/container';
 import {Plus} from 'react-feather';
+import {useLocation, useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 const ActionBarContainer = styled(Container)`
@@ -80,6 +82,9 @@ const commitStatusToButtonState = (
  * ActionBar that contains a button to commit/uncommit/pay a listing.
  */
 const ActionBar: React.FC = () => {
+  const history = useHistory();
+  const {state: locationState, pathname} = useLocation<ListingLocation>();
+
   const {commitStatus, onCommit, onUncommit} = useCommitContext();
   const {
     onOpen: onOpenFulfilmentDetailsPrompt,
@@ -88,6 +93,11 @@ const ActionBar: React.FC = () => {
 
   const [buttonState, setButtonState] = useState<ActionButtonState>('initial');
   const [button, setButton] = useState(<></>);
+
+  if (locationState?.attemptPayment && buttonState === 'awaitingPayment') {
+    history.replace(pathname, {...locationState, attemptPayment: false});
+    onOpenFulfilmentDetailsPrompt();
+  }
 
   const getButton = useCallback(
     (buttonState: ActionButtonState): JSX.Element => {

--- a/web/src/components/customer/listing-details/index.tsx
+++ b/web/src/components/customer/listing-details/index.tsx
@@ -25,6 +25,10 @@ import CommitFeedbackPromptContext from 'components/customer/listing-details/con
 import FulfilmentDetailsPromptProvider from 'components/customer/listing-details/contexts/FulfilmentDetailsPromptContext';
 import ListingDetailsContext from 'components/customer/listing-details/contexts/ListingDetailsContext';
 import FulfilmentDetailsPrompt from 'components/customer/listing-details/FulfulmentDetailsPrompt';
+import {
+  ListingLocation,
+  ListingParams,
+} from 'components/customer/listing-details/interfaces';
 import ListingDetails from 'components/customer/listing-details/ListingDetails';
 import {useHistory, useParams, useLocation} from 'react-router-dom';
 import styled from 'styled-components';
@@ -43,23 +47,15 @@ const ContentContainer = styled.div`
   overflow: scroll;
 `;
 
-interface ListingParams {
-  listingId: string;
-}
-
-interface ListingLocation {
-  hasBack: boolean;
-}
-
 const ListingDetailsPage: React.FC = () => {
   const history = useHistory();
-  const location = useLocation<ListingLocation>();
+  const {state: locationState} = useLocation<ListingLocation>();
   const {listingId: listingIdStr} = useParams<ListingParams>();
 
   const listingId = Number(listingIdStr);
 
   const handleBack = () =>
-    location.state?.hasBack ? history.goBack() : history.push('/');
+    locationState?.hasBack ? history.goBack() : history.push('/');
 
   return (
     <CommitFeedbackPromptContext>

--- a/web/src/components/customer/listing-details/interfaces.ts
+++ b/web/src/components/customer/listing-details/interfaces.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Location state of the /listing/:listingId route.
+ */
+export interface ListingLocation {
+  hasBack: boolean;
+  attemptPayment: boolean;
+}
+
+/**
+ * Route params of the /listing/:listingId route.
+ */
+export interface ListingParams {
+  listingId: string;
+}

--- a/web/src/components/customer/listing-details/interfaces.ts
+++ b/web/src/components/customer/listing-details/interfaces.ts
@@ -19,7 +19,7 @@
  */
 export interface ListingLocation {
   hasBack: boolean;
-  attemptPayment: boolean;
+  attemptPayment?: boolean;
 }
 
 /**

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -57,6 +57,7 @@ const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
             pathname: `listing/${listing.id}`,
             state: {
               hasBack: true,
+              attemptPayment: true,
             },
           }}
           key={idx}

--- a/web/src/components/customer/my-commits/Commits.tsx
+++ b/web/src/components/customer/my-commits/Commits.tsx
@@ -34,9 +34,13 @@ const CommitsContainer = styled.div`
 `;
 interface CommitSectionProps {
   commits: Commit[];
+  directToPayment?: boolean;
 }
 
-const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
+const CommitSection: React.FC<CommitSectionProps> = ({
+  commits,
+  directToPayment,
+}) => {
   const [listings, setListings] = useState<Listing[]>([]);
 
   useEffect(() => {
@@ -57,7 +61,7 @@ const CommitSection: React.FC<CommitSectionProps> = ({commits}) => {
             pathname: `listing/${listing.id}`,
             state: {
               hasBack: true,
-              attemptPayment: true,
+              attemptPayment: directToPayment || false,
             },
           }}
           key={idx}
@@ -84,7 +88,7 @@ const Commits: React.FC<CommitsProps> = ({
 }) => (
   <CommitsContainer>
     <h2>Awaiting Payment</h2>
-    {successful && <CommitSection commits={successful} />}
+    {successful && <CommitSection commits={successful} directToPayment />}
     <h2>Ongoing</h2>
     {ongoing && <CommitSection commits={ongoing} />}
     <h2>History</h2>


### PR DESCRIPTION
# Changes
- Directly lead customers to payment flow from My Commits "Pay" button
  * Done by adding `attemptPayment` to the location state.

# Screenshot demo
**Clicking on the first listing**
![Screenshot 2020-08-04 at 2 24 57 PM](https://user-images.githubusercontent.com/25261058/89272750-32ca7900-d671-11ea-8e39-a9fd00722ae9.png)
**Will directly lead you to:**
![Screenshot 2020-08-04 at 4 30 07 PM](https://user-images.githubusercontent.com/25261058/89272746-31994c00-d671-11ea-8789-ef3d6a10091d.png)
When user clicks on "Back" in the prompt, user will see the listing details page
Clicking on other listings in My Commits page that are not ready for payment will not trigger the prompt 