### PR TITLE
Add loading prompt while processing payment

### DIFF
--- a/web/src/components/common/MobilePrompt.tsx
+++ b/web/src/components/common/MobilePrompt.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 
 import Modal from 'components/common/Modal';
-import {NonEmptyArray} from 'interfaces';
 import Button from 'muicss/lib/react/button';
 import Container from 'muicss/lib/react/container';
 import styled from 'styled-components';
@@ -86,7 +85,7 @@ interface ButtonDetails {
 interface MobilePromptProps {
   isVisible: boolean;
   title: string;
-  buttons: NonEmptyArray<ButtonDetails>;
+  buttons: ButtonDetails[];
   header?: JSX.Element;
 }
 

--- a/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
+++ b/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
@@ -17,6 +17,7 @@
 import React, {useState, useEffect} from 'react';
 
 import CommitsBadge from 'components/common/CommitsBadge';
+import Loading from 'components/common/Loading';
 import MobilePrompt from 'components/common/MobilePrompt';
 import {useCommitFeedbackPromptContext} from 'components/customer/listing-details/contexts/CommitFeedbackPromptContext';
 
@@ -80,6 +81,17 @@ const CommitStatusPrompt: React.FC = () => {
             isVisible={isPromptVisible}
             onClose={onClose}
           />
+        );
+        break;
+      case 'loading':
+        setPrompt(
+          <MobilePrompt
+            title="Please wait..."
+            isVisible={isPromptVisible}
+            buttons={[]}
+          >
+            <Loading />
+          </MobilePrompt>
         );
         break;
       default:

--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -137,6 +137,7 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
       return;
     }
 
+    onOpenPrompt('loading');
     const commit = await payForCommit(commitId, {fulfilmentDetails}, idToken);
     // TODO: Handle payment error
     await refetchCustomer();

--- a/web/src/components/customer/listing-details/contexts/CommitFeedbackPromptContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitFeedbackPromptContext.tsx
@@ -16,7 +16,7 @@
 
 import React, {useContext, useState} from 'react';
 
-type PromptContent = 'successful-commit' | 'successful-payment';
+type PromptContent = 'successful-commit' | 'successful-payment' | 'loading';
 
 type ContextType =
   | {


### PR DESCRIPTION
# Changes
- Adding a loading prompt which opens when payment is processing

**Screenshot demo for what happens after clicking confirm**
![Screenshot 2020-08-04 at 6 00 50 PM](https://user-images.githubusercontent.com/25261058/89283834-6a8ced00-d680-11ea-8f33-465da512158a.png)
![Screenshot 2020-08-04 at 6 23 55 PM](https://user-images.githubusercontent.com/25261058/89283844-6e207400-d680-11ea-99fd-1b1fe26a46fe.png)
![Screenshot 2020-08-04 at 6 01 05 PM](https://user-images.githubusercontent.com/25261058/89283851-6fea3780-d680-11ea-9123-c41eb23e265c.png)
