### PR TITLE
Add set default checkbox to fulfillment details form

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -56,6 +56,28 @@ const postWithAuth = async (
 };
 
 /**
+ * Helper function that wraps the fetch call to make a patch request with Auth headers.
+ * @param endpoint Endpoint of the request
+ * @param data Request body data
+ * @param token Auth token
+ */
+const patchWithAuth = async (
+  endpoint: string,
+  data: object,
+  token: string
+): Promise<Response> => {
+  const requestOptions = {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  };
+  return fetch(endpoint, requestOptions);
+};
+
+/**
  * Helper method that wraps the fetch call to make a delete request with Auth headers.
  * @param endpoint Endpoint of the request
  * @param token Auth token
@@ -113,6 +135,20 @@ export const loginCustomer = async (
 ): Promise<Customer> => {
   const res = await postWithAuth(
     `${process.env.REACT_APP_SERVER_URL}/customers`,
+    customerData,
+    idToken
+  );
+
+  return res.json();
+};
+
+export const updateCustomer = async (
+  customerId: number,
+  customerData: CustomerPayload,
+  idToken: string
+): Promise<Customer> => {
+  const res = await patchWithAuth(
+    `${process.env.REACT_APP_SERVER_URL}/customers/${customerId}`,
     customerData,
     idToken
   );

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -144,7 +144,7 @@ export const loginCustomer = async (
 
 export const updateCustomer = async (
   customerId: number,
-  customerData: CustomerPayload,
+  customerData: Partial<CustomerPayload>,
   idToken: string
 ): Promise<Customer> => {
   const res = await patchWithAuth(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -142,14 +142,20 @@ export const loginCustomer = async (
   return res.json();
 };
 
+/**
+ * Updates the specified fields of a customer with the specified customerId.
+ * @param customerId Id of the customer to be updated
+ * @param fieldsToUpdate Data that we want to update
+ * @param idToken Authentication token of customer
+ */
 export const updateCustomer = async (
   customerId: number,
-  customerData: Partial<CustomerPayload>,
+  fieldsToUpdate: Partial<CustomerPayload>,
   idToken: string
 ): Promise<Customer> => {
   const res = await patchWithAuth(
     `${process.env.REACT_APP_SERVER_URL}/customers/${customerId}`,
-    customerData,
+    fieldsToUpdate,
     idToken
   );
 

--- a/web/src/components/common/FormRow.tsx
+++ b/web/src/components/common/FormRow.tsx
@@ -221,7 +221,11 @@ const FormRow: React.FC<FormRowProps> = ({
   const isStacked = type === 'checkbox' ? false : stacked;
 
   return (
-    <StyledRow fullWidth={inputWidth === undefined} stacked={isStacked} checkbox={type === 'checkbox'}>
+    <StyledRow
+      fullWidth={inputWidth === undefined}
+      stacked={isStacked}
+      checkbox={type === 'checkbox'}
+    >
       <StyledCol>
         <Label stacked={isStacked}>{label}</Label>
       </StyledCol>

--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -16,7 +16,13 @@
 
 import React, {useContext, useState, useEffect} from 'react';
 
-import {getCommits, addCommit, deleteCommit, payForCommit, updateCustomer} from 'api';
+import {
+  getCommits,
+  addCommit,
+  deleteCommit,
+  payForCommit,
+  updateCustomer,
+} from 'api';
 import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
 import {useCommitFeedbackPromptContext} from 'components/customer/listing-details/contexts/CommitFeedbackPromptContext';
 import {CommitStatus, FulfilmentDetails} from 'interfaces';
@@ -26,7 +32,10 @@ type ContextType =
       commitStatus: CommitStatus | undefined;
       onCommit: () => Promise<void>;
       onUncommit: () => Promise<void>;
-      onPayment: (fulfilmentDetails: FulfilmentDetails, setDefault?: boolean) => Promise<void>;
+      onPayment: (
+        fulfilmentDetails: FulfilmentDetails,
+        setDefault?: boolean
+      ) => Promise<void>;
     }
   | undefined;
 
@@ -126,7 +135,10 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
     setCommitStatus(undefined);
   };
 
-  const onPayment = async (fulfilmentDetails: FulfilmentDetails, setDefault?: boolean) => {
+  const onPayment = async (
+    fulfilmentDetails: FulfilmentDetails,
+    setDefault?: boolean
+  ) => {
     if (commitId === undefined) {
       return;
     }
@@ -142,7 +154,11 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
     // TODO: Handle payment error
 
     if (setDefault) {
-      await updateCustomer(customer.id, {defaultFulfilmentDetails: fulfilmentDetails}, idToken)
+      await updateCustomer(
+        customer.id,
+        {defaultFulfilmentDetails: fulfilmentDetails},
+        idToken
+      );
     }
     await refetchCustomer();
     setCommitStatus(commit.commitStatus);

--- a/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
+++ b/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
@@ -27,7 +27,9 @@ interface FulFilmentDetailsSubmittedValues extends FulfilmentDetails {
  * the Fulfilment Details form.
  */
 const useFulfilmentDetailsForm = () => {
-  const { formState, handleSubmit, register } = useForm<FulFilmentDetailsSubmittedValues>({
+  const {formState, handleSubmit, register} = useForm<
+    FulFilmentDetailsSubmittedValues
+  >({
     mode: 'onChange',
   });
   const {onPayment} = useCommitContext();
@@ -58,14 +60,16 @@ const useFulfilmentDetailsForm = () => {
     },
     address: {
       required: true,
-    }
+    },
   };
   const disabled = !formState.isValid;
 
-  const onSubmit = handleSubmit(async (values: FulFilmentDetailsSubmittedValues) => {
-    const {setDefault, ...fulfilmentDetails} = values;
-    return onPayment(fulfilmentDetails, setDefault);
-  });
+  const onSubmit = handleSubmit(
+    async (values: FulFilmentDetailsSubmittedValues) => {
+      const {setDefault, ...fulfilmentDetails} = values;
+      return onPayment(fulfilmentDetails, setDefault);
+    }
+  );
 
   return {
     fields,

--- a/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
+++ b/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
@@ -18,12 +18,16 @@ import {useCommitContext} from 'components/customer/listing-details/contexts/Com
 import {FulfilmentDetails} from 'interfaces';
 import {useForm} from 'react-hook-form';
 
+interface FulFilmentDetailsSubmittedValues extends FulfilmentDetails {
+  setDefault: boolean;
+}
+
 /**
  * useFulfilmentDetailsForm that contains all the logic and details concering
  * the Fulfilment Details form.
  */
 const useFulfilmentDetailsForm = () => {
-  const {formState, handleSubmit, register} = useForm<FulfilmentDetails>({
+  const { formState, handleSubmit, register } = useForm<FulFilmentDetailsSubmittedValues>({
     mode: 'onChange',
   });
   const {onPayment} = useCommitContext();
@@ -35,6 +39,11 @@ const useFulfilmentDetailsForm = () => {
       label: 'Delivery Address',
       name: 'address',
       type: 'textarea',
+    },
+    {
+      label: 'Use as default',
+      name: 'setDefault',
+      type: 'checkbox',
     },
   ];
 
@@ -49,12 +58,13 @@ const useFulfilmentDetailsForm = () => {
     },
     address: {
       required: true,
-    },
+    }
   };
   const disabled = !formState.isValid;
 
-  const onSubmit = handleSubmit(async (values: FulfilmentDetails) => {
-    return onPayment(values);
+  const onSubmit = handleSubmit(async (values: FulFilmentDetailsSubmittedValues) => {
+    const {setDefault, ...fulfilmentDetails} = values;
+    return onPayment(fulfilmentDetails, setDefault);
   });
 
   return {

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -195,7 +195,7 @@ export type GroupedCommits = {
  */
 export interface CustomerPayload {
   gpayId: string;
-  defaultFulfilmentDetails: FulfilmentDetails;
+  defaultFulfilmentDetails?: FulfilmentDetails;
 }
 
 /**

--- a/web/src/interfaces.ts
+++ b/web/src/interfaces.ts
@@ -195,8 +195,7 @@ export type GroupedCommits = {
  */
 export interface CustomerPayload {
   gpayId: string;
-  contactNumber?: string; // E164 format
-  address?: string;
+  defaultFulfilmentDetails: FulfilmentDetails;
 }
 
 /**


### PR DESCRIPTION
To be merged after #195 

Part of #167 

# Changes
- Added checkbox in fulfilment details form which allows customer to save their delivery details for future reference

**TODOs, not in this PR:**
- Autofill saved defaultFulfilmentDetails the next time user pays

![Screenshot 2020-08-06 at 1 18 28 PM](https://user-images.githubusercontent.com/25261058/89494005-de95d500-d7e7-11ea-8161-d906306e0bc1.png)
![image](https://user-images.githubusercontent.com/25261058/89494020-e5244c80-d7e7-11ea-8987-342e062eef20.png)
**Datastore reflects submitted fulfilment details in `defaultFulfilmentDetails`**
![Screenshot 2020-08-06 at 12 11 27 PM](https://user-images.githubusercontent.com/25261058/89494023-e81f3d00-d7e7-11ea-8993-70ea27583966.png)
