### PR TITLE
Add missing `await` in addEntityHelper

### DIFF
--- a/server/src/storage/datastore.ts
+++ b/server/src/storage/datastore.ts
@@ -268,7 +268,7 @@ const addEntityHelper = async (
 
   try {
     if (uniqueProperties === undefined) {
-      actor.insert(entity);
+      await actor.insert(entity);
     } else if (actor instanceof Datastore) {
       await insertUniqueEntity(kind, entity, uniqueProperties);
     } else if (actor instanceof Transaction) {


### PR DESCRIPTION
### Motivation
Without the `await`, there are several problems:
- Function returns without resolving the promise/async function. So, any error/promise rejection might not be thrown to the function caller.
- `key` variable does not have `id` property. So, the returned object will be `NaN` instead of the id of the added entity.

Adding the word `await` solves these issues.