### PR TITLE
Handle errors in datastore layer

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,6 +29,7 @@ import {
   merchantRouter,
 } from './api';
 import errorHandler from './middleware/error-handler';
+import errorMapper from './middleware/error-mapper';
 import {NotFoundError} from './utils/http-errors';
 
 const app: express.Application = express();
@@ -58,8 +59,8 @@ app.use(() => {
   throw new NotFoundError('Not Found');
 });
 
-// Handles the sending the error messages to client.
-app.use(errorHandler);
+// Handles the sending of error messages to client.
+app.use(errorMapper, errorHandler);
 
 const localPort = process.env.NODE_ENV === 'test' ? 5001 : 5000;
 const port = process.env.PORT || localPort;

--- a/server/src/middleware/error-mapper.ts
+++ b/server/src/middleware/error-mapper.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Request, Response, NextFunction} from 'express';
+
+import {
+  ConflictError,
+  NotFoundError,
+  BadRequestError,
+  InternalServerError,
+} from '../utils/http-errors';
+import {
+  StorageError,
+  EntityAlreadyExistsError,
+  EntityNotFoundError,
+  PropertyMismatchError,
+} from '../utils/storage-errors';
+
+/**
+ * Middleware that maps each StorageError to a HttpError and rethrow it.
+ */
+const errorMapper = (
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (err instanceof StorageError) {
+    switch (err.constructor) {
+      case EntityAlreadyExistsError:
+        throw new ConflictError(err.message);
+      case EntityNotFoundError:
+        throw new NotFoundError(err.message);
+      case PropertyMismatchError:
+        throw new BadRequestError(err.message);
+      default:
+        throw new InternalServerError(err.message);
+    }
+  }
+  next(err);
+};
+
+export default errorMapper;

--- a/server/src/utils/storage-errors.ts
+++ b/server/src/utils/storage-errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A general storage error class which contains the error message of an error.
+ * Refer to https://cloud.google.com/datastore/docs/concepts/errors for more about
+ * Datastore errors.
+ */
+export class StorageError extends Error {
+  constructor(message: string) {
+    super();
+    this.message = message;
+  }
+}
+
+/**
+ * Indicates an attempt to insert an entity that already exists.
+ */
+export class EntityAlreadyExistsError extends StorageError {}
+
+/**
+ * Indicates an attempt to perform a storage operation on an entity that does
+ * not exist.
+ */
+export class EntityNotFoundError extends StorageError {}
+
+/**
+ * Indicates an attempt to perform an update operation on an entity's property,
+ * but the property does not exist on the existing entity.
+ */
+export class PropertyMismatchError extends StorageError {}

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -46,8 +46,7 @@ describe('Customers endpoints', () => {
 
     const res = await request(app).get(`/customers/${customerId}`);
 
-    // TODO: Test for actual error status codes when implemented
-    expect(res.status).not.toBe(200);
+    expect(res.status).toBe(404);
     expect(res.body).toHaveProperty('error');
     expect(res.body.error.message).toBe(
       `Customer ${customerId} does not exist`

--- a/server/tests/integration/merchants.test.ts
+++ b/server/tests/integration/merchants.test.ts
@@ -46,8 +46,7 @@ describe('Merchants endpoints', () => {
 
       const res = await request(app).get(`/merchants/${merchantId}`);
 
-      // TODO: Test for actual error status codes when implemented
-      expect(res.status).not.toBe(200);
+      expect(res.status).toBe(404);
       expect(res.body).toHaveProperty('error');
       expect(res.body.error.message).toBe(
         `Merchant ${merchantId} does not exist`


### PR DESCRIPTION
Closes #210 

# Changes
- Handle datastore layer errors and throw them as the appropriate `StorageError`s
- Added `error-mapper` middleware which maps each `StorageError` to a `HttpError` and throws it as the appropriate `HttpError`
- Modified tests to test for the exact status codes