### PR TITLE
Add customer access control middlewares

### DIFF
--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -71,14 +71,19 @@ commitRouter.post(
     };
     next();
   },
-  customerAccessControl(async (req: Request) => {
-    const customerId = Number(req.validated.body.customerId);
-    const customer = await customerService.getCustomer(customerId);
-    return customer.gpayId;
-  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const customerId = Number(req.validated.body.customerId);
+      const customer = await customerService.getCustomer(customerId);
+      req.authorizedCustomerGPayId = customer.gpayId;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  },
+  customerAccessControl,
   async (req: Request, res: Response, next: NextFunction) => {
     const commitData = req.validated.body as CommitRequest;
-
     try {
       const addedCommit = await commitService.addCommit(commitData);
       const resourceUrl = `${process.env.SERVER_URL}/commits/${addedCommit.id}`;
@@ -117,11 +122,19 @@ commitRouter.post(
     };
     next();
   },
-  customerAccessControl(async (req: Request) => {
-    const commit = await commitService.getCommit(req.validated.params.commitId);
-    const customer = await customerService.getCustomer(commit.customerId);
-    return customer.gpayId;
-  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const commit = await commitService.getCommit(
+        req.validated.params.commitId
+      );
+      const customer = await customerService.getCustomer(commit.customerId);
+      req.authorizedCustomerGPayId = customer.gpayId;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  },
+  customerAccessControl,
   async (req: Request, res: Response, next: NextFunction) => {
     const {commitId} = req.validated.params;
     const paymentRequest: CommitPaymentRequest = req.validated.body;
@@ -179,11 +192,19 @@ commitRouter.delete(
     };
     next();
   },
-  customerAccessControl(async (req: Request) => {
-    const commit = await commitService.getCommit(req.validated.params.commitId);
-    const customer = await customerService.getCustomer(commit.customerId);
-    return customer.gpayId;
-  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const commit = await commitService.getCommit(
+        req.validated.params.commitId
+      );
+      const customer = await customerService.getCustomer(commit.customerId);
+      req.authorizedCustomerGPayId = customer.gpayId;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  },
+  customerAccessControl,
   async (req: Request, res: Response, next: NextFunction) => {
     const {commitId} = req.validated.params;
 

--- a/server/src/api/commits.ts
+++ b/server/src/api/commits.ts
@@ -21,9 +21,10 @@
 import express, {Request, Response, NextFunction} from 'express';
 
 import {CommitRequest, CommitPaymentRequest} from '../interfaces';
+import customerAccessControl from '../middleware/customer-access-control';
 import customerAuth from '../middleware/customer-auth';
 import validateAndFormatPhoneNumber from '../middleware/validation/phone-number';
-import {commitService} from '../services';
+import {commitService, customerService} from '../services';
 import {BadRequestError} from '../utils/http-errors';
 
 const commitRouter = express.Router();
@@ -57,12 +58,26 @@ commitRouter.post(
   '/',
   customerAuth,
   async (req: Request, res: Response, next: NextFunction) => {
-    // TODO: Parse req.body json to make it CommitRequest type in runtime.
-    // Right now I am forcing it to be of the correct types.
-    const commitData: CommitRequest = {
-      customerId: Number(req.body.customerId),
-      listingId: Number(req.body.listingId),
+    const {customerId: customerIdStr, listingId: listingIdStr} = req.body;
+    const customerId = Number(customerIdStr);
+    const listingId = Number(listingIdStr);
+
+    if (Number.isNaN(customerId) || Number.isNaN(listingId)) {
+      return next(new BadRequestError('Invalid request body'));
+    }
+    req.validated = {
+      ...req,
+      body: {customerId, listingId},
     };
+    next();
+  },
+  customerAccessControl(async (req: Request) => {
+    const customerId = Number(req.validated.body.customerId);
+    const customer = await customerService.getCustomer(customerId);
+    return customer.gpayId;
+  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const commitData = req.validated.body as CommitRequest;
 
     try {
       const addedCommit = await commitService.addCommit(commitData);
@@ -91,15 +106,28 @@ commitRouter.post(
     const {commitId: commitIdStr} = req.params;
     const commitId = Number(commitIdStr);
 
+    if (Number.isNaN(commitId)) {
+      return next(new BadRequestError(`Invalid commitId ${commitIdStr}`));
+    }
+
     // TODO: Parse req.body json to make it CommitPaymentRequest type in runtime.
-    // TODO: Ensure that the commit belongs to the authenticated customer.
+    req.validated = {
+      ...req,
+      params: {commitId},
+    };
+    next();
+  },
+  customerAccessControl(async (req: Request) => {
+    const commit = await commitService.getCommit(req.validated.params.commitId);
+    const customer = await customerService.getCustomer(commit.customerId);
+    return customer.gpayId;
+  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const {commitId} = req.validated.params;
+    const paymentRequest: CommitPaymentRequest = req.validated.body;
 
     try {
-      if (Number.isNaN(commitId)) {
-        throw new BadRequestError(`Invalid commitId ${commitIdStr}`);
-      }
-
-      const commit = await commitService.payForCommit(commitId, req.body);
+      const commit = await commitService.payForCommit(commitId, paymentRequest);
       res.status(200).json(commit);
     } catch (error) {
       return next(error);
@@ -142,11 +170,24 @@ commitRouter.delete(
     const {commitId: commitIdStr} = req.params;
     const commitId = Number(commitIdStr);
 
-    try {
-      if (Number.isNaN(commitId)) {
-        throw new BadRequestError(`Invalid commitId ${commitIdStr}`);
-      }
+    if (Number.isNaN(commitId)) {
+      return next(new BadRequestError(`Invalid commitId ${commitIdStr}`));
+    }
+    req.validated = {
+      ...req,
+      params: {commitId},
+    };
+    next();
+  },
+  customerAccessControl(async (req: Request) => {
+    const commit = await commitService.getCommit(req.validated.params.commitId);
+    const customer = await customerService.getCustomer(commit.customerId);
+    return customer.gpayId;
+  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const {commitId} = req.validated.params;
 
+    try {
       await commitService.deleteCommit(commitId);
       res.sendStatus(204);
     } catch (error) {

--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -21,6 +21,7 @@
 import {Router, Request, Response, NextFunction} from 'express';
 
 import {CustomerPayload} from '../interfaces';
+import customerAccessControl from '../middleware/customer-access-control';
 import customerAuth from '../middleware/customer-auth';
 import validateAndFormatPhoneNumber from '../middleware/validation/phone-number';
 import {customerService} from '../services';
@@ -58,7 +59,13 @@ customerRouter.post(
   '/',
   customerAuth,
   async (req: Request, res: Response, next: NextFunction) => {
-    const customerData: CustomerPayload = req.body;
+    // TODO: Ensure that req.body is of type CustomerPayload
+    req.validated = req;
+    next();
+  },
+  customerAccessControl((req: Request) => req.validated.body.gpayId),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const customerData: CustomerPayload = req.validated.body;
 
     try {
       // Customers are unique by their gpayId, so we will retrieve
@@ -101,13 +108,27 @@ customerRouter.patch(
   async (req: Request, res: Response, next: NextFunction) => {
     const {customerId: customerIdStr} = req.params;
     const customerId = Number(customerIdStr);
-    const fieldsToUpdate = req.body;
+
+    if (Number.isNaN(customerId)) {
+      return next(new BadRequestError(`Invalid customerId ${customerIdStr}`));
+    }
+    req.validated = {
+      ...req,
+      params: {customerId},
+    };
+    next();
+  },
+  customerAccessControl(async (req: Request) => {
+    const customer = await customerService.getCustomer(
+      req.validated.params.customerId
+    );
+    return customer.gpayId;
+  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const {customerId} = req.validated.params;
+    const fieldsToUpdate = req.validated.body;
 
     try {
-      if (Number.isNaN(customerId)) {
-        throw new BadRequestError(`Invalid customerId ${customerIdStr}`);
-      }
-
       const modifiedCustomer = await customerService.updateCustomer(
         customerId,
         fieldsToUpdate

--- a/server/src/custom-typings/express/index.d.ts
+++ b/server/src/custom-typings/express/index.d.ts
@@ -23,5 +23,6 @@ declare namespace Express {
   interface Request {
     validated: ValidatedRequest;
     decodedCustomer?: null | { [key: string]: any } | string;
+    authorizedCustomerGPayId?: string;
   }
 }

--- a/server/src/custom-typings/express/index.d.ts
+++ b/server/src/custom-typings/express/index.d.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+interface ValidatedRequest {
+  body: any;
+  params: { [key: string]: any };
+}
+
 declare namespace Express {
   interface Request {
-    decodedCustomer?: object;
+    validated: ValidatedRequest;
+    decodedCustomer?: null | { [key: string]: any } | string;
   }
 }

--- a/server/src/middleware/__mocks__/customer-access-control.ts
+++ b/server/src/middleware/__mocks__/customer-access-control.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Imported for typing purposes
+import type customerAccessControlMiddleware from '../customer-access-control';
+
+const customerAccessControlOriginalImpl = jest.requireActual(
+  '../customer-access-control'
+).default;
+
+const customerAccessControlMockedImpl: typeof customerAccessControlMiddleware = (
+  req,
+  res,
+  next
+) => {
+  next();
+};
+
+/**
+ * Mocked instance of customerAccessControl.
+ */
+export const customerAccessControl = jest.fn(customerAccessControlMockedImpl);
+
+/**
+ * Apply mock implementation of customer auth once.
+ */
+export const mockCustomerAccessControl = () => {
+  customerAccessControl.mockImplementationOnce(customerAccessControlMockedImpl);
+};
+
+/**
+ * Remove fake implementations of mocks and restore actual implementation.
+ */
+export const restoreCustomerAccessControl = () => {
+  customerAccessControl.mockImplementation(customerAccessControlOriginalImpl);
+};
+
+export default customerAccessControl;

--- a/server/src/middleware/customer-access-control.ts
+++ b/server/src/middleware/customer-access-control.ts
@@ -26,8 +26,6 @@ import {
  * Authorizes a customer.
  * Requires req.authorizedCustomerGpayId to be set in order for this
  * access control middleware to work.
- * @params getGpayIdOfAuthorizedCustomer Getter function to get gpayId of
- * an authorized customer
  */
 const customerAccessControl = (
   req: Request,

--- a/server/src/middleware/customer-access-control.ts
+++ b/server/src/middleware/customer-access-control.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Request, Response, NextFunction} from 'express';
+
+import {UnauthorizedError, ForbiddenError} from '../utils/http-errors';
+
+/**
+ * Authorizes a customer.
+ * @params getGpayIdOfAuthorizedCustomer Getter function to get gpayId of
+ * an authorized customer
+ */
+const customerAccessControl = (
+  getGpayIdOfAuthorizedCustomer: (req: Request) => string | Promise<string>
+) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const decodedIdTokenOfCurrCustomer = req.decodedCustomer;
+      if (
+        decodedIdTokenOfCurrCustomer === undefined ||
+        decodedIdTokenOfCurrCustomer === null
+      ) {
+        throw new UnauthorizedError('Invalid Authorization token format.');
+      }
+
+      const {sub: gpayIdOfCurrCustomer} = decodedIdTokenOfCurrCustomer;
+      if (gpayIdOfCurrCustomer === undefined) {
+        throw new UnauthorizedError('User cannot be identified.');
+      }
+
+      const gpayIdOfAuthorizedCustomer = await getGpayIdOfAuthorizedCustomer(
+        req
+      );
+      if (gpayIdOfCurrCustomer !== gpayIdOfAuthorizedCustomer) {
+        throw new ForbiddenError(
+          'Not allowed to modify or access requested resource.'
+        );
+      }
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+};
+
+export default customerAccessControl;

--- a/server/src/services/commits.ts
+++ b/server/src/services/commits.ts
@@ -29,6 +29,13 @@ import {commitStorage, listingStorage, customerStorage} from '../storage';
 import {BadRequestError} from '../utils/http-errors';
 
 /**
+ * Retrieves commit with the specified commitId.
+ * @param commitId Id of the commit to retrieve
+ */
+const getCommit = async (commitId: number) =>
+  await commitStorage.getCommit(commitId);
+
+/**
  * Retrieves all commits.
  * If query paramaters are provided, will retrieve all commits satisfying
  * the query parameters.
@@ -186,6 +193,7 @@ const deleteCommit = async (commitId: number) => {
 };
 
 export default {
+  getCommit,
   getAllCommits,
   addCommit,
   payForCommit,

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -99,7 +99,7 @@ describe('Customers endpoints', () => {
       expect(res.body.error.message).toBe('Missing Authorization token.');
     });
 
-    test('Should require customer access control', async () => {
+    test('Should call customer access control', async () => {
       mockCustomerAuth();
 
       await request(app).post('/customers');
@@ -115,7 +115,7 @@ describe('Customers endpoints', () => {
 
       const res = await request(app).post('/customers').send({gpayId});
 
-      // expect(res.status).toBe(403);
+      expect(res.status).toBe(403);
       expect(res.body).toHaveProperty('error');
       expect(res.body.error.message).toBe(
         'Not allowed to modify or access requested resource.'
@@ -165,7 +165,7 @@ describe('Customers endpoints', () => {
       expect(res.body.error.message).toBe('Missing Authorization token.');
     });
 
-    test('Should require customer access control', async () => {
+    test('Should call customer access control', async () => {
       mockCustomerAuth();
       const customerId = customerFixtures.ids?.[0];
 

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -17,22 +17,32 @@
 import request from 'supertest';
 
 import app from '../../src';
+import * as mockedCustomerAccessControl from '../../src/middleware/__mocks__/customer-access-control';
 import * as mockedCustomerAuth from '../../src/middleware/__mocks__/customer-auth';
+import * as customerAccessControlMiddleware from '../../src/middleware/customer-access-control';
 import * as customerAuthMiddleware from '../../src/middleware/customer-auth';
 import customerFixtures from '../fixtures/customers';
 
 // Mock middlewares
 jest.mock('../../src/middleware/customer-auth');
+jest.mock('../../src/middleware/customer-access-control');
 
 const {
-  mockCustomerAuth,
   customerAuth,
   restoreCustomerAuth,
+  mockCustomerAuth,
 } = customerAuthMiddleware as typeof mockedCustomerAuth;
 
-// Disable customer auth mock implementation by default
+const {
+  customerAccessControl,
+  restoreCustomerAccessControl,
+  mockCustomerAccessControl,
+} = customerAccessControlMiddleware as typeof mockedCustomerAccessControl;
+
+// Disable customer auth and access control mock implementation by default
 beforeAll(() => {
   restoreCustomerAuth();
+  restoreCustomerAccessControl();
 });
 
 describe('Customers endpoints', () => {
@@ -89,9 +99,33 @@ describe('Customers endpoints', () => {
       expect(res.body.error.message).toBe('Missing Authorization token.');
     });
 
+    test('Should require customer access control', async () => {
+      mockCustomerAuth();
+
+      await request(app).post('/customers');
+
+      expect(customerAccessControl).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should reject if customer is not authorized', async () => {
+      mockCustomerAuth();
+
+      const expectedCustomerData = customerFixtures.responseData?.[0];
+      const gpayId = expectedCustomerData.gpayId;
+
+      const res = await request(app).post('/customers').send({gpayId});
+
+      // expect(res.status).toBe(403);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error.message).toBe(
+        'Not allowed to modify or access requested resource.'
+      );
+    });
+
     describe('Authenticated requests', () => {
       beforeEach(() => {
         mockCustomerAuth();
+        mockCustomerAccessControl();
       });
 
       // TODO: Add test for 'Should create a new customer if customer does not exist'
@@ -131,9 +165,32 @@ describe('Customers endpoints', () => {
       expect(res.body.error.message).toBe('Missing Authorization token.');
     });
 
+    test('Should require customer access control', async () => {
+      mockCustomerAuth();
+      const customerId = customerFixtures.ids?.[0];
+
+      await request(app).patch(`/customers/${customerId}`);
+
+      expect(customerAccessControl).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should reject if customer is not authorized', async () => {
+      mockCustomerAuth();
+      const customerId = customerFixtures.ids?.[0];
+
+      const res = await request(app).patch(`/customers/${customerId}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error.message).toBe(
+        'Not allowed to modify or access requested resource.'
+      );
+    });
+
     describe('Authenticated requests', () => {
       beforeEach(() => {
         mockCustomerAuth();
+        mockCustomerAccessControl();
       });
 
       test('Should modify an existing customer', async () => {


### PR DESCRIPTION
Closes #119

# Background
Previously, we only check for authentication of customers, and did not have access control restrictions. This means that as long as I have a valid token, I can make requests to modify another customer's commits and customer data. This is not desirable and this PR fixes this by adding a layer of access control to restricted customer endpoints. 

# Changes
- Added access control middleware that checks if customer is authorized to access/modify the resource they have requested
  * This middleware requires a prior middleware to add an authorized gpay id to `req.authorizedCustomerGPayId` before it can be checked in the `customerAccessControl` middleware. 
(Initially, I wanted `customerAccessControl` middleware to be a higher order function (as seen in the very first commit of this PR), but it was too much of a pain to mock it, and in view of the tight deadline, I decided to change it to this current pattern instead)
- Hoisted validation code in the `api` layer to _above_ the `customerAccessControl` middleware, because we don't want the part that sets `req.authorizedCustomerGPayId` to skip validations
- Added tests & a test mock for the middleware
