### PR TITLE
Update contact number format

### DIFF
--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -80,7 +80,10 @@ export interface CommitRequest {
 interface FulfilmentDetails {
   name: string;
   address: string;
-  contactNumber: string; // E164 format
+  // contactNumber format is E.123 international notation
+  // Note that the national phone number portion will only contain digits (no spaces)
+  // Eg: +91 1234567890
+  contactNumber: string;
 }
 
 /**

--- a/server/src/middleware/validation/phone-number.ts
+++ b/server/src/middleware/validation/phone-number.ts
@@ -23,11 +23,13 @@ import {BadRequestError} from '../../utils/http-errors';
 type PhoneNumberGetter = (body: any) => string | undefined;
 type PhoneNumberSetter = (body: any, phoneNumber: string) => void;
 
-const e164Format = PhoneNumberFormat.E164;
 const phoneUtil = PhoneNumberUtil.getInstance();
 
 /**
- * Validates and format a phone number.
+ * Middleware that validates and format a phone number.
+ * The resultant phone number format is E.123 international notation.
+ * Note that the national phone number portion will only contain digits (no spaces).
+ * Eg: +91 1234567890
  */
 const validateAndFormatPhoneNumber = (
   getPhoneNumber: PhoneNumberGetter,
@@ -52,10 +54,9 @@ const validateAndFormatPhoneNumber = (
         throw new BadRequestError('Invalid phone number.');
       }
 
-      const formattedPhoneNumber = phoneUtil.format(
-        parsedPhoneNumber,
-        e164Format
-      );
+      const countryCode = parsedPhoneNumber.getCountryCodeOrDefault();
+      const nationalNUmber = parsedPhoneNumber.getNationalNumberOrDefault();
+      const formattedPhoneNumber = `+${countryCode} ${nationalNUmber}`;
       setPhoneNumber(req.body, formattedPhoneNumber);
       next();
     } catch (err) {

--- a/server/src/middleware/validation/phone-number.ts
+++ b/server/src/middleware/validation/phone-number.ts
@@ -20,8 +20,10 @@ import {PhoneNumberUtil} from 'google-libphonenumber';
 import {REGION_CODE_IN} from '../../constants/common';
 import {BadRequestError} from '../../utils/http-errors';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type PhoneNumberGetter = (body: any) => string | undefined;
 type PhoneNumberSetter = (body: any, phoneNumber: string) => void;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const phoneUtil = PhoneNumberUtil.getInstance();
 

--- a/server/src/middleware/validation/phone-number.ts
+++ b/server/src/middleware/validation/phone-number.ts
@@ -15,7 +15,7 @@
  */
 
 import {Request, Response, NextFunction} from 'express';
-import {PhoneNumberUtil, PhoneNumberFormat} from 'google-libphonenumber';
+import {PhoneNumberUtil} from 'google-libphonenumber';
 
 import {REGION_CODE_IN} from '../../constants/common';
 import {BadRequestError} from '../../utils/http-errors';

--- a/server/tests/fixtures/customers.ts
+++ b/server/tests/fixtures/customers.ts
@@ -22,7 +22,7 @@ const data = [
     defaultFulfilmentDetails: {
       name: 'John Doe',
       address: 'Blk 42, Serangoon Road, #01-22',
-      contactNumber: '+911234567890',
+      contactNumber: '+91 1234567890',
     },
     gpayId: 1,
   },
@@ -30,7 +30,7 @@ const data = [
     defaultFulfilmentDetails: {
       name: 'Mary Jane',
       address: 'Blk 2, Ang Mo Kio Ave 10, #18-02',
-      contactNumber: '+910987654321',
+      contactNumber: '+91 0987654321',
     },
     gpayId: 2,
   },
@@ -38,7 +38,7 @@ const data = [
     defaultFulfilmentDetails: {
       name: 'Polar Bear',
       address: 'Blk 7, Pasir Ris St 72, #05-01',
-      contactNumber: '+911029384756',
+      contactNumber: '+91 1029384756',
     },
     gpayId: 3,
   },

--- a/server/tests/integration/customers.test.ts
+++ b/server/tests/integration/customers.test.ts
@@ -199,7 +199,7 @@ describe('Customers endpoints', () => {
         const defaultFulfilmentDetails = {
           name: 'Pusheen Takoyaki',
           address: 'Disneyland',
-          contactNumber: '+911234567890',
+          contactNumber: '+91 1234567890',
         };
         const expectedCustomerData = {
           ...originalCustomerData,
@@ -241,7 +241,7 @@ describe('Customers endpoints', () => {
         const defaultFulfilmentDetails = {
           name: 'Pusheen Takoyaki',
           address: 'Disneyland',
-          contactNumber: '+6591234567',
+          contactNumber: '+65 91234567',
         };
 
         const res = await request(app).patch(`/customers/${customerId}`).send({


### PR DESCRIPTION
To be merged after #214 

# Changes
- In view of the addition of `gpayContactNumber` to `CustomerPayload` as seen in #213, this PR updates `contactNumber` format to have a space between country code and the national number, to be consistent with how gpay stores their phone numbers

![Screenshot 2020-08-17 at 1 12 42 PM](https://user-images.githubusercontent.com/25261058/90363117-a9656e80-e094-11ea-998c-4b29f0b43e04.png)
