### PR TITLE
Update gpayContactNumber upon customer login

### DIFF
--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -58,6 +58,12 @@ customerRouter.get(
 customerRouter.post(
   '/',
   customerAuth,
+  validateAndFormatPhoneNumber(
+    (body: Partial<CustomerPayload>) => body.gpayContactNumber,
+    (body: Partial<CustomerPayload>, phoneNumber: string) =>
+      (body.gpayContactNumber = phoneNumber),
+    false
+  ),
   async (req: Request, res: Response, next: NextFunction) => {
     // TODO: Ensure that req.body is of type CustomerPayload
     req.validated = req;
@@ -74,10 +80,24 @@ customerRouter.post(
     try {
       // Customers are unique by their gpayId, so we will retrieve
       // the customer using their gpay Id.
-      const existingCustomer = await customerService.getCustomerWithGpayId(
+      let existingCustomer = await customerService.getCustomerWithGpayId(
         customerData.gpayId
       );
       if (existingCustomer !== null) {
+        // Update gpayContactNumber if it does not match
+        const {gpayContactNumber} = customerData;
+        if (
+          gpayContactNumber &&
+          existingCustomer.gpayContactNumber !== gpayContactNumber
+        ) {
+          existingCustomer = await customerService.updateCustomer(
+            existingCustomer.id,
+            {
+              gpayContactNumber,
+            }
+          );
+        }
+
         const resourceUrl = `${process.env.SERVER_URL}/customers/${existingCustomer.id}`;
         res.setHeader('Content-Location', resourceUrl);
         res.status(200).send(existingCustomer);

--- a/server/src/api/customers.ts
+++ b/server/src/api/customers.ts
@@ -50,10 +50,12 @@ customerRouter.get(
 
 /**
  * Endpoint for the "logging in" of customers.
- * If the customer exists, return the customer details in the
- * response body with code 200.
- * Else, add the customer and return the added customer details
- * in the response body with code 201.
+ * If the customer does not exists, add the customer and return the
+ * added customer details in the response body with code 201.
+ * Else if the customer exists, we check if the provided gpayContactNumber
+ * matches the gpayContactNumber of the existing customer, and update it
+ * if it does not match. The endpoint then returns the customer details in
+ * the response body with code 200.
  */
 customerRouter.post(
   '/',

--- a/server/src/constants/default-payload.ts
+++ b/server/src/constants/default-payload.ts
@@ -26,6 +26,7 @@ export const DEFAULT_CUSTOMER_PAYLOAD = {
     address: '',
     contactNumber: '',
   },
+  gpayContactNumber: '',
 };
 
 /**

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -22,6 +22,10 @@ import {Operator} from '@google-cloud/datastore/build/src/query';
  */
 export interface CustomerPayload {
   gpayId: string;
+  // gpayContactNumber format is E.123 international notation
+  // Note that the national phone number portion will only contain digits (no spaces)
+  // Eg: +91 1234567890
+  gpayContactNumber: string;
   defaultFulfilmentDetails: FulfilmentDetails;
 }
 

--- a/server/src/middleware/validation/phone-number.ts
+++ b/server/src/middleware/validation/phone-number.ts
@@ -32,10 +32,15 @@ const phoneUtil = PhoneNumberUtil.getInstance();
  * The resultant phone number format is E.123 international notation.
  * Note that the national phone number portion will only contain digits (no spaces).
  * Eg: +91 1234567890
+ * @params getPhoneNumber Getter function for getting the phone number from req body
+ * @params setPhoneNumber Setter function for setting the phone number to req body
+ * @params requireIndiaRegion Indicates if we should check if the phone number is
+ * local to India region.
  */
 const validateAndFormatPhoneNumber = (
   getPhoneNumber: PhoneNumberGetter,
-  setPhoneNumber: PhoneNumberSetter
+  setPhoneNumber: PhoneNumberSetter,
+  requireIndiaRegion = true
 ) => {
   return (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -50,9 +55,11 @@ const validateAndFormatPhoneNumber = (
         REGION_CODE_IN
       );
 
-      if (
-        !phoneUtil.isValidNumberForRegion(parsedPhoneNumber, REGION_CODE_IN)
-      ) {
+      const isValidNumber = requireIndiaRegion
+        ? phoneUtil.isValidNumberForRegion(parsedPhoneNumber, REGION_CODE_IN)
+        : phoneUtil.isValidNumber(parsedPhoneNumber);
+
+      if (!isValidNumber) {
         throw new BadRequestError('Invalid phone number.');
       }
 

--- a/server/src/services/customers.ts
+++ b/server/src/services/customers.ts
@@ -63,6 +63,7 @@ const updateCustomer = async (
   // Check that request contains only allowed keys
   const allowedKeys: Set<CustomerPayloadKey> = new Set([
     'defaultFulfilmentDetails',
+    'gpayContactNumber',
   ]);
   Object.keys(fieldsToUpdate).forEach(key => {
     if (!(allowedKeys as Set<string>).has(key)) {

--- a/server/tests/fixtures/customers.ts
+++ b/server/tests/fixtures/customers.ts
@@ -25,6 +25,7 @@ const data = [
       contactNumber: '+91 1234567890',
     },
     gpayId: 1,
+    gpayContactNumber: '+91 1234567890',
   },
   {
     defaultFulfilmentDetails: {
@@ -33,6 +34,7 @@ const data = [
       contactNumber: '+91 0987654321',
     },
     gpayId: 2,
+    gpayContactNumber: '+91 0987654321',
   },
   {
     defaultFulfilmentDetails: {
@@ -41,6 +43,7 @@ const data = [
       contactNumber: '+91 1029384756',
     },
     gpayId: 3,
+    gpayContactNumber: '+91 1029384756',
   },
 ];
 


### PR DESCRIPTION
Part of #217
To be merged after #215 

# Changes
- Added `gpayContactNumber` field to `CustomerPayload` to allow #213 as the Spot API requires the customer's contact number in gpay in order for our Spot to send messages to the customers
  * We initially wanted to use a [Payment recipient](https://developers.google.com/pay/spot/eap/reference/messages-api#payment-recipient) but we are unable to call that payments API, so we settled with [Phone Number recipient](https://developers.google.com/pay/spot/eap/reference/messages-api#phone-number-recipient)
- When an existing customer signs in with a different `gpayContactNumber` from its previous value, we will update the `gpayContactNumber` of the customer to the newer one 
  * This is because in GPay, customers can change their phone numbers and we will have no idea if the customer changed it or not. Hence, we have decided to send customer's gpay phone number along with the login endpoint, and update it in our database if there is a change.

# Screenshots
The below screenshots show 2 different `gpayContactNumber` body fields when trying to login the same customer (same `gpayId`)
![Screenshot 2020-08-17 at 2 36 56 PM](https://user-images.githubusercontent.com/25261058/90369782-ea628080-e09e-11ea-9b78-5b8637c8d9ce.png)
![Screenshot 2020-08-17 at 2 37 39 PM](https://user-images.githubusercontent.com/25261058/90369779-e898bd00-e09e-11ea-855e-a1c7d34c77ce.png)
