### PR TITLE
Autofill fulfilment details form

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -14,6 +14,9 @@
   "rules": {
     // Permits comparing to null with "==" to check for null or undefined
     "eqeqeq": [2, "allow-null"],
+    "@typescript-eslint/no-unused-vars": [1, {
+      "varsIgnorePattern": "^_"
+    }],
     "import/order": [
       "error",
       {

--- a/web/package.json
+++ b/web/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "EXTEND_ESLINT=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "yarn lint:code && yarn lint:css",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -99,7 +99,7 @@ const deleteWithAuth = async (endpoint: string, token: string) => {
  */
 const query = async (
   endpoint: string,
-  queryParams: Record<string, any>
+  queryParams: Record<string, unknown>
 ): Promise<Response> => {
   const strParams: Record<string, string> = {};
   Object.keys(queryParams).forEach(
@@ -107,7 +107,7 @@ const query = async (
   );
 
   const url = new URL(endpoint);
-  const params = new URLSearchParams(queryParams).toString();
+  const params = new URLSearchParams(strParams).toString();
   url.search = params;
 
   return fetch(url.toString());

--- a/web/src/components/common/FormRow.tsx
+++ b/web/src/components/common/FormRow.tsx
@@ -182,7 +182,7 @@ const FormRow: React.FC<FormRowProps> = ({
   inputStyle = 'flat',
 }) => {
   const {fields, errors, register, validations} = useFormPropsContext();
-  const {name, label, type} = fields[index];
+  const {name, label, type, defaultValue} = fields[index];
 
   const getInput = useCallback(() => {
     switch (type) {
@@ -194,7 +194,9 @@ const FormRow: React.FC<FormRowProps> = ({
             ref={register(validations[name])}
             inputWidth={inputWidth}
             inputStyle={inputStyle}
-          />
+          >
+            {defaultValue}
+          </TextArea>
         );
       case 'checkbox':
         return (
@@ -213,10 +215,20 @@ const FormRow: React.FC<FormRowProps> = ({
             ref={register(validations[name])}
             inputWidth={inputWidth}
             inputStyle={inputStyle}
+            defaultValue={defaultValue}
           />
         );
     }
-  }, [type, name, validations, register, inputStyle, inputWidth, textAreaRows]);
+  }, [
+    type,
+    name,
+    validations,
+    register,
+    inputStyle,
+    inputWidth,
+    textAreaRows,
+    defaultValue,
+  ]);
 
   const isStacked = type === 'checkbox' ? false : stacked;
 

--- a/web/src/components/common/contexts/FormPropsContext.tsx
+++ b/web/src/components/common/contexts/FormPropsContext.tsx
@@ -33,6 +33,7 @@ interface Field {
   label: string;
   name: string;
   type: string;
+  defaultValue?: string | number;
 }
 
 type ContextType =

--- a/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
+++ b/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
@@ -18,11 +18,7 @@ import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
 import {useCommitContext} from 'components/customer/listing-details/contexts/CommitContext';
 import {FulfilmentDetails} from 'interfaces';
 import {useForm} from 'react-hook-form';
-
-const formatContactNumber = (contactNum: string) => {
-  const [_, nationalNumber] = contactNum.split(' ');
-  return nationalNumber;
-};
+import {getNationalNumber} from 'utils/phone-number';
 
 interface FulFilmentDetailsSubmittedValues extends FulfilmentDetails {
   setDefault: boolean;
@@ -52,11 +48,12 @@ const useFulfilmentDetailsForm = () => {
       label: 'Contact Number',
       name: 'contactNumber',
       type: 'number',
-      defaultValue: formatContactNumber(
-        customer?.defaultFulfilmentDetails.contactNumber ||
-          customer?.gpayContactNumber ||
-          ''
-      ),
+      defaultValue:
+        customer &&
+        getNationalNumber(
+          customer.defaultFulfilmentDetails.contactNumber ||
+            customer.gpayContactNumber
+        ),
     },
     {
       label: 'Delivery Address',

--- a/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
+++ b/web/src/components/customer/listing-details/hooks/useFulfilmentDetailsForm.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+import {useCustomerContext} from 'components/customer/contexts/CustomerContext';
 import {useCommitContext} from 'components/customer/listing-details/contexts/CommitContext';
 import {FulfilmentDetails} from 'interfaces';
 import {useForm} from 'react-hook-form';
+
+const formatContactNumber = (contactNum: string) => {
+  const [_, nationalNumber] = contactNum.split(' ');
+  return nationalNumber;
+};
 
 interface FulFilmentDetailsSubmittedValues extends FulfilmentDetails {
   setDefault: boolean;
@@ -33,14 +39,30 @@ const useFulfilmentDetailsForm = () => {
     mode: 'onChange',
   });
   const {onPayment} = useCommitContext();
+  const {customer} = useCustomerContext();
 
   const fields = [
-    {label: 'Name', name: 'name', type: 'text'},
-    {label: 'Contact Number', name: 'contactNumber', type: 'number'},
+    {
+      label: 'Name',
+      name: 'name',
+      type: 'text',
+      defaultValue: customer?.defaultFulfilmentDetails.name,
+    },
+    {
+      label: 'Contact Number',
+      name: 'contactNumber',
+      type: 'number',
+      defaultValue: formatContactNumber(
+        customer?.defaultFulfilmentDetails.contactNumber ||
+          customer?.gpayContactNumber ||
+          ''
+      ),
+    },
     {
       label: 'Delivery Address',
       name: 'address',
       type: 'textarea',
+      defaultValue: customer?.defaultFulfilmentDetails.address,
     },
     {
       label: 'Use as default',

--- a/web/src/microapps.ts
+++ b/web/src/microapps.ts
@@ -25,7 +25,7 @@ const microapps = window.microapps;
 const MICROAPP_BASE_URL = `https://microapps.google.com/${process.env.REACT_APP_SPOT_ID}`;
 
 let cachedIdentity: CustomerIdentity;
-let cachedDecodedPhoneNumberToken: any; // eslint-ignore-line @typescript-eslint/no-explicit-any
+let cachedDecodedPhoneNumberToken: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 /**
  * Decodes a base64 microapps identity token.

--- a/web/src/microapps.ts
+++ b/web/src/microapps.ts
@@ -25,7 +25,7 @@ const microapps = window.microapps;
 const MICROAPP_BASE_URL = `https://microapps.google.com/${process.env.REACT_APP_SPOT_ID}`;
 
 let cachedIdentity: CustomerIdentity;
-let cachedDecodedPhoneNumberToken: any;
+let cachedDecodedPhoneNumberToken: any; // eslint-ignore-line @typescript-eslint/no-explicit-any
 
 /**
  * Decodes a base64 microapps identity token.

--- a/web/src/utils/phone-number/index.ts
+++ b/web/src/utils/phone-number/index.ts
@@ -16,7 +16,7 @@
 
 /**
  * Simple function that retrieves the national number of the input phone number,
- * with the assumption tha the input phone number follows our standard phone
+ * with the assumption that the input phone number follows our standard phone
  * number format.
  * Eg input: '+91 1234567890'
  * Eg output: '1234567890'

--- a/web/src/utils/phone-number/index.ts
+++ b/web/src/utils/phone-number/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Simple function that retrieves the national number of the input phone number,
+ * with the assumption tha the input phone number follows our standard phone
+ * number format.
+ * Eg input: '+91 1234567890'
+ * Eg output: '1234567890'
+ * @param phoneNumber Phone number in E.123 international notation with no spaces
+ * for the national phone number portion
+ */
+export const getNationalNumber = (phoneNumber: string): string => {
+  const [_, nationalNumber] = phoneNumber.split(' ');
+  return nationalNumber;
+};

--- a/web/src/utils/phone-number/phone-number.test.ts
+++ b/web/src/utils/phone-number/phone-number.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getNationalNumber} from 'utils/phone-number';
+
+describe('getNationalNumber', () => {
+  test('it should extract national number accurately', () => {
+    const numberInputs = ['+91 1234567890', '+65 81234567'];
+    const expectedValues = ['1234567890', '81234567'];
+
+    numberInputs.forEach((numberInput, idx) => {
+      expect(getNationalNumber(numberInput)).toBe(expectedValues[idx]);
+    });
+  });
+});


### PR DESCRIPTION
To be merged after #218 
Closes #163, Closes #167

# Changes
- Autofill fulfilment details form for customer
  * If they have previously checked the `Use as default` checkbox when paying for an item, the form will now autofill with the exact same delivery details the next time the fulfilment details form pops up
  * If not, the form will autofill the contact number portion with their `gpayContactNumber`

# Screenshots
**This is how the Datastore entity for this user looks like**
![image](https://user-images.githubusercontent.com/25261058/90389709-a54d4700-e0bc-11ea-8fef-ad5ee84c6a2a.png)

**Autofill with `defaultFulfilmentDetails`**
![Screenshot 2020-08-17 at 6 30 28 PM](https://user-images.githubusercontent.com/25261058/90389755-b4cc9000-e0bc-11ea-8280-967d81b86fbd.png)

**Autofill with `gpayContactNumber` (I removed the default details fields to test this flow)**
![image](https://user-images.githubusercontent.com/25261058/90389663-8f3f8680-e0bc-11ea-8be0-3785a6addc1e.png)
