### PR TITLE
Add phone number fallback UI for flows that require login

### DIFF
--- a/web/src/components/common/MobilePrompt.tsx
+++ b/web/src/components/common/MobilePrompt.tsx
@@ -40,6 +40,8 @@ const PromptContent = styled.section`
 
   padding-top: 18px;
 
+  text-align: center;
+
   & > * {
     margin: 6px 0 6px 0;
   }

--- a/web/src/components/customer/contexts/CustomerContext.tsx
+++ b/web/src/components/customer/contexts/CustomerContext.tsx
@@ -65,12 +65,10 @@ const CustomerProvider: React.FC = ({children}) => {
 
   const login = useCallback(async (): Promise<AuthenticatedCustomer> => {
     const identity = await getIdentity();
-    if (identity === undefined) {
+    const gpayContactNumber = await getPhoneNumber();
+    if (identity === undefined || gpayContactNumber === undefined) {
       return {customer: undefined, idToken: undefined};
     }
-
-    const gpayContactNumber = (await getPhoneNumber()) || '';
-    // TODO: Handle customer refuse to provide phone number case
 
     const {
       idToken,

--- a/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
+++ b/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
@@ -107,7 +107,12 @@ const CommitStatusPrompt: React.FC = () => {
                 onClick: onClose,
               },
             ]}
-          />
+          >
+            <p>
+              Please sign in to Group Buy with your Google account and grant us
+              access to your Google Pay phone number.
+            </p>
+          </MobilePrompt>
         );
         break;
       default:


### PR DESCRIPTION
To be merged after #218 

# Changes
- Added fallback UI for flows that require login (both identity and phone number permissions must be granted, else fallback UI will show)

![Screenshot 2020-08-17 at 8 32 53 PM](https://user-images.githubusercontent.com/25261058/90397325-48f12400-e0ca-11ea-9cad-7d95dc7e0e23.png)
