### PR TITLE
Add generic commit feedback error prompt

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -233,7 +233,13 @@ export const addCommit = async (
     commitData,
     idToken
   );
-  return res.json();
+
+  const resData = await res.json();
+
+  if (!res.ok) {
+    throw new Error(resData.error?.message);
+  }
+  return resData;
 };
 
 /**
@@ -242,10 +248,16 @@ export const addCommit = async (
  * @param idToken Authentication token of customer
  */
 export const deleteCommit = async (commitId: number, idToken: string) => {
-  await deleteWithAuth(
+  const res = await deleteWithAuth(
     `${process.env.REACT_APP_SERVER_URL}/commits/${commitId}`,
     idToken
   );
+
+  if (!res.ok) {
+    const resData = await res.json();
+    throw new Error(resData.error?.message);
+  }
+  return;
 };
 
 /**
@@ -264,7 +276,13 @@ export const payForCommit = async (
     paymentData,
     idToken
   );
-  return res.json();
+
+  const resData = await res.json();
+
+  if (!res.ok) {
+    throw new Error(resData.error?.message);
+  }
+  return resData;
 };
 
 /**

--- a/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
+++ b/web/src/components/customer/listing-details/CommitFeedbackPrompt.tsx
@@ -115,6 +115,21 @@ const CommitStatusPrompt: React.FC = () => {
           </MobilePrompt>
         );
         break;
+      case 'error':
+        setPrompt(
+          <MobilePrompt
+            title="Something went wrong, please try again later."
+            header={<NotifySvg />}
+            isVisible={isPromptVisible}
+            buttons={[
+              {
+                name: 'Dismiss',
+                onClick: onClose,
+              },
+            ]}
+          />
+        );
+        break;
       default:
         throw new Error('Unsupported prompt content.');
     }

--- a/web/src/components/customer/listing-details/contexts/CommitFeedbackPromptContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitFeedbackPromptContext.tsx
@@ -20,7 +20,8 @@ type PromptContent =
   | 'successful-commit'
   | 'successful-payment'
   | 'loading'
-  | 'require-login';
+  | 'require-login'
+  | 'error';
 
 type ContextType =
   | {


### PR DESCRIPTION
# Changes
- Show a generic commit feedback error prompt when committing, uncommitting, or paying for a commit fails
  * Due to time constraint, we will use this generic error prompt. If time permits, we can set up more specific error prompts.

This is how it looks like:
![Screenshot 2020-08-19 at 1 15 56 PM](https://user-images.githubusercontent.com/25261058/90595331-30dee900-e21f-11ea-8336-c149ba62566d.png)
