### PR TITLE
Use defaultValue prop instead of children for textarea 

### DIFF
--- a/web/src/components/common/FormRow.tsx
+++ b/web/src/components/common/FormRow.tsx
@@ -194,9 +194,8 @@ const FormRow: React.FC<FormRowProps> = ({
             ref={register(validations[name])}
             inputWidth={inputWidth}
             inputStyle={inputStyle}
-          >
-            {defaultValue}
-          </TextArea>
+            defaultValue={defaultValue}
+          />
         );
       case 'checkbox':
         return (


### PR DESCRIPTION
# Changes
- Instead of setting as children for the default value of the textarea, change to use `defaultValue` prop instead. This silenced a warning from react which indicated that we should use `defaultValue` prop instead