### PR TITLE
Fix misaligned form labels

### DIFF
--- a/web/src/components/common/MobilePrompt.tsx
+++ b/web/src/components/common/MobilePrompt.tsx
@@ -40,7 +40,9 @@ const PromptContent = styled.section`
 
   padding-top: 18px;
 
-  text-align: center;
+  & > p {
+    text-align: center;
+  }
 
   & > * {
     margin: 6px 0 6px 0;


### PR DESCRIPTION
# Changes
- Made `text-align: center` only apply to `p` tags, so as not to affect the text alignment of other text in a prompt

Previously, the `text-align: center` in MobilePrompt was causing misaligned form labels:
![Screenshot 2020-08-19 at 1 52 11 PM](https://user-images.githubusercontent.com/25261058/90597796-53bfcc00-e224-11ea-9292-a626bc6576ef.png)

This PR fixes it:
![Screenshot 2020-08-19 at 1 53 06 PM](https://user-images.githubusercontent.com/25261058/90597837-6934f600-e224-11ea-996f-95a049c865a2.png)

