### PR TITLE
Add loading prompt for commiting and uncommitting

### DIFF
--- a/web/src/components/customer/listing-details/contexts/CommitContext.tsx
+++ b/web/src/components/customer/listing-details/contexts/CommitContext.tsx
@@ -71,7 +71,10 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
     refetchCustomer,
   } = useCustomerContext();
 
-  const {onOpen: onOpenPrompt} = useCommitFeedbackPromptContext();
+  const {
+    onOpen: onOpenPrompt,
+    onClose: onClosePrompt,
+  } = useCommitFeedbackPromptContext();
 
   const [commitStatus, setCommitStatus] = useState<CommitStatus>();
   const [commitId, setCommitId] = useState<number | undefined>();
@@ -103,6 +106,7 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
       return;
     }
 
+    onOpenPrompt('loading');
     try {
       const commit = await addCommit(
         {
@@ -139,12 +143,14 @@ const CommitContextProvider: React.FC<CommitContextProps> = ({
       return;
     }
 
+    onOpenPrompt('loading');
     try {
       await deleteCommit(commitId, idToken);
 
       setCommitId(undefined);
       await refetchCustomer();
       setCommitStatus(undefined);
+      onClosePrompt();
     } catch {
       onOpenPrompt('error');
     }


### PR DESCRIPTION
# Changes
- Added loading prompt for commiting and uncommitting, before the confirmation/failure prompt appears
  * uncommitting does not have a confirmation prompt if successful, so we have to explicitly ask the prompt to close after a successful uncommit with `onClosePrompt()`

# Screenshots
After clicking Commit for a listing:
![Screenshot 2020-08-19 at 5 04 31 PM](https://user-images.githubusercontent.com/25261058/90615299-81b20a00-e23e-11ea-8ab5-8f3a7814ef04.png)
![Screenshot 2020-08-19 at 5 04 37 PM](https://user-images.githubusercontent.com/25261058/90615302-837bcd80-e23e-11ea-843d-eed1151d863d.png)
