### PR TITLE
Customise primary and disabled muicss button colors

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -68,3 +68,12 @@ h1 {
   font-weight: bold;
   font-size: 2em;
 }
+
+.mui-btn--primary, .mui-btn--primary:focus {
+  background-color: var(--green);
+}
+
+.mui-btn--is-disabled, .mui-btn:disabled {
+  background-color: var(--gray);
+  color: white;
+}


### PR DESCRIPTION
# Changes
- Set muicss primary color to green and disabled color to gray to match our UI Mock 

**Green primary buttons**
![image](https://user-images.githubusercontent.com/25261058/90618977-4108bf80-e243-11ea-8d87-f09c199eadcd.png)
**Gray disabled button**
![Screenshot 2020-08-19 at 5 36 43 PM](https://user-images.githubusercontent.com/25261058/90619054-5a117080-e243-11ea-8fb1-278fe1dbb2a9.png)
