### PR TITLE
Fix word wrap bug in commit status badge

### DIFF
--- a/web/src/components/common/ListingCard.tsx
+++ b/web/src/components/common/ListingCard.tsx
@@ -53,7 +53,13 @@ const detailsRowStyle = css`
 `;
 
 const ChildrenContainer = styled.div`
-  flex: 1;
+  display: flex;
+  flex-direction: column;
+  flex: auto;
+`;
+
+const DetailsContent = styled.div`
+  flex: auto;
 `;
 
 const Details = styled.div`
@@ -113,10 +119,10 @@ const ListingCard: React.FC<ListingCardProps> = ({
       <CardContent>
         <DeadlineTag deadline={endDate} />
         <Details childrenPos={childrenPos}>
-          <div>
+          <DetailsContent>
             <ListingName>{listingName}</ListingName>
             <ListingPrice price={price} oldPrice={oldPrice} />
-          </div>
+          </DetailsContent>
           <ChildrenContainer>{children}</ChildrenContainer>
         </Details>
       </CardContent>

--- a/web/src/components/customer/my-commits/CommitStatusBadge.tsx
+++ b/web/src/components/customer/my-commits/CommitStatusBadge.tsx
@@ -36,10 +36,11 @@ const grayedStyle = css`
 
 const BadgeContainer = styled.div`
   min-width: 3em;
-  max-width: fit-content;
+  max-width: 6em;
   padding: 0.5em 1em;
   border-radius: 15px;
 
+  word-break: normal;
   text-transform: uppercase;
   font-weight: bold;
   text-align: center;
@@ -81,6 +82,7 @@ const getBadgeText = (commitStatus: CommitStatus) => {
 
 interface CommitStatusBadgeProps {
   commitStatus: CommitStatus;
+  className?: string; // Prop passed by styled-components wrapper.
 }
 
 /**
@@ -88,8 +90,9 @@ interface CommitStatusBadgeProps {
  */
 const CommitStatusBadge: React.FC<CommitStatusBadgeProps> = ({
   commitStatus,
+  className,
 }) => (
-  <BadgeContainer commitStatus={commitStatus}>
+  <BadgeContainer commitStatus={commitStatus} className={className}>
     {getBadgeText(commitStatus)}
   </BadgeContainer>
 );

--- a/web/src/components/customer/my-commits/ListingCardWithCommitStatus.tsx
+++ b/web/src/components/customer/my-commits/ListingCardWithCommitStatus.tsx
@@ -20,6 +20,11 @@ import ListingCard from 'components/common/ListingCard';
 import StrippedCol from 'components/common/StrippedCol';
 import CommitStatusBadge from 'components/customer/my-commits/CommitStatusBadge';
 import {Listing, CommitStatus} from 'interfaces';
+import styled from 'styled-components';
+
+const StyledCommitStatusBadge = styled(CommitStatusBadge)`
+  align-self: flex-end;
+`;
 
 interface ListingCardProps {
   listing: Listing;
@@ -43,7 +48,7 @@ const ListingCardWithCommitStatus: React.FC<ListingCardProps> = ({
       horizontal
       childrenPos="right"
     >
-      <CommitStatusBadge commitStatus={commitStatus} />
+      <StyledCommitStatusBadge commitStatus={commitStatus} />
     </ListingCard>
   </StrippedCol>
 );


### PR DESCRIPTION
# Changes
- Fixed bug in My Commits page listing commit status badge, where the text in the badge tend to wrap in weird manners

# Screenshots
Before:
![Screenshot 2020-08-18 at 12 00 20 AM](https://user-images.githubusercontent.com/25261058/90627975-5e438b00-e24f-11ea-8d65-32624a4d2ae5.png)

After:
![Screenshot 2020-08-19 at 7 06 11 PM](https://user-images.githubusercontent.com/25261058/90627937-4b30bb00-e24f-11ea-940e-13e4d487bd35.png)
 