### PR TITLE
Fix muicss primary and disabled color

### DIFF
--- a/web/src/components/common/MobilePrompt.tsx
+++ b/web/src/components/common/MobilePrompt.tsx
@@ -77,6 +77,7 @@ const LinkButton = styled(Button)`
 
   && {
     color: var(--green);
+    background: none;
   }
 `;
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -69,7 +69,10 @@ h1 {
   font-size: 2em;
 }
 
-.mui-btn--primary, .mui-btn--primary:focus {
+.mui-btn--primary,
+.mui-btn--primary:focus,
+.mui-btn--primary:active,
+.mui-btn--primary:hover {
   background-color: var(--green);
 }
 


### PR DESCRIPTION
# Changes
- I realised that the primary color is switching back to blue occasionally, and dug deeper to find out that there were psuedo classes that I was missing out, so this PR adds that in
- Set background of button in mobile prompt to none so that disabled buttons don't have a gray background